### PR TITLE
Add the ability to define HANA pre & post install tasks

### DIFF
--- a/ansible/roles/sap-hana-ha/README.md
+++ b/ansible/roles/sap-hana-ha/README.md
@@ -87,6 +87,10 @@ Running GCE instances deployed using the terraform code under `stacks/HANA-HA`
 
 `sap_hana_logvols`: List of logical volumes to create on the system
 
+`sap_hana_preinstall_tasks`: Path to an Ansible task file that will run before HANA is installed. This can be an absolute path, or a relative path which is relative to the playbook directory.
+
+`sap_hana_postinstall_tasks`: Path to an Ansible task file that will run after HANA is installed. This can be an absolute path, or a relative path which is relative to the playbook directory.
+
 # Defaults:
 
 All the defaults for this role are defined in `defaults/main.yml`

--- a/ansible/roles/sap-hana-install/defaults/main.yml
+++ b/ansible/roles/sap-hana-install/defaults/main.yml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+sap_hana_preinstall_tasks: ''
+sap_hana_postinstall_tasks: ''
+
 # Response variables for unattended installation config file
 
 sap_hana_deployment_hdblcm_extraargs:

--- a/ansible/roles/sap-hana-install/tasks/main.yml
+++ b/ansible/roles/sap-hana-install/tasks/main.yml
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Run preinstall tasks
+  include_tasks: '{{ sap_hana_preinstall_tasks }}'
+  when: sap_hana_preinstall_tasks != ''
+
 - name: Define install file name
   set_fact:
     sap_hana_install_file_name: '{{ sap_product_vars[sap_product_and_version].sap_hana_install_file_name }}'
@@ -143,3 +147,7 @@
         - not hana_db_running.stat.exists
   when:
     - sap_hana_install_file_name.endswith(".ZIP") and (exe_install_file.matched == 0)
+
+- name: Run postinstall tasks
+  include_tasks: '{{ sap_hana_postinstall_tasks }}'
+  when: sap_hana_postinstall_tasks != ''

--- a/ansible/roles/sap-hana-scaleout/README.md
+++ b/ansible/roles/sap-hana-scaleout/README.md
@@ -87,6 +87,10 @@ Running GCE instance deployed using the terraform code under `stacks/HANA-Scaleo
 
 `sap_hana_logvols`: List of logical volumes to create on the system
 
+`sap_hana_preinstall_tasks`: Path to an Ansible task file that will run before HANA is installed. This can be an absolute path, or a relative path which is relative to the playbook directory.
+
+`sap_hana_postinstall_tasks`: Path to an Ansible task file that will run after HANA is installed. This can be an absolute path, or a relative path which is relative to the playbook directory.
+
 # Defaults:
 
 All the defaults for this role are defined in `defaults/main.yml`

--- a/ansible/roles/sap-hana-scaleup/README.md
+++ b/ansible/roles/sap-hana-scaleup/README.md
@@ -77,6 +77,10 @@ Running GCE instance deployed using the terraform code under `stacks/HANA-Scaleu
 
 `sap_hana_logvols`: List of logical volumes to create on the system
 
+`sap_hana_preinstall_tasks`: Path to an Ansible task file that will run before HANA is installed. This can be an absolute path, or a relative path which is relative to the playbook directory.
+
+`sap_hana_postinstall_tasks`: Path to an Ansible task file that will run after HANA is installed. This can be an absolute path, or a relative path which is relative to the playbook directory.
+
 # Defaults:
 
 All the defaults for this role are defined in `defaults/main.yml`

--- a/stacks/HANA-HA/README.md
+++ b/stacks/HANA-HA/README.md
@@ -85,6 +85,10 @@ m2-ultramem-416
 
 `sap_hana_password`: Common password to use for all HANA user and system authentication
 
+`sap_hana_preinstall_tasks`: Path to an Ansible task file that will run before HANA is installed. This can be an absolute path, or a relative path which is relative to the playbook directory.
+
+`sap_hana_postinstall_tasks`: Path to an Ansible task file that will run after HANA is installed. This can be an absolute path, or a relative path which is relative to the playbook directory.
+
 # Example playbook to deploy SAP HANA HA stack
 
 Below is the example playbook to deploy the HANA HA stack. Replace the variable values to fit your need

--- a/stacks/HANA-Scaleout/README.md
+++ b/stacks/HANA-Scaleout/README.md
@@ -79,6 +79,10 @@ m2-ultramem-416
 
 `sap_hana_password`: Common password to use for all HANA user and system authentication
 
+`sap_hana_preinstall_tasks`: Path to an Ansible task file that will run before HANA is installed. This can be an absolute path, or a relative path which is relative to the playbook directory.
+
+`sap_hana_postinstall_tasks`: Path to an Ansible task file that will run after HANA is installed. This can be an absolute path, or a relative path which is relative to the playbook directory.
+
 # Example playbook to deploy SAP HANA Scaleout stack
 
 Below is the example playbook to deploy the HANA Scaleout stack. Replace the variable values to fit your need

--- a/stacks/HANA-Scaleup/README.md
+++ b/stacks/HANA-Scaleup/README.md
@@ -77,6 +77,10 @@ m2-ultramem-416
 
 `sap_hana_password`: Common password to use for all HANA user and system authentication
 
+`sap_hana_preinstall_tasks`: Path to an Ansible task file that will run before HANA is installed. This can be an absolute path, or a relative path which is relative to the playbook directory.
+
+`sap_hana_postinstall_tasks`: Path to an Ansible task file that will run after HANA is installed. This can be an absolute path, or a relative path which is relative to the playbook directory.
+
 # Example playbook to deploy SAP HANA Scaleup stack
 
 Below is the example playbook to deploy the HANA scaleup stack. Replace the variable values to fit your need


### PR DESCRIPTION
This adds two new variables, `sap_hana_preinstall_tasks` and
`sap_hana_postinstall_tasks`, which each take a path to an Ansible task file
that will run before or after HANA is installed. This works for any of the
roles `sap-hana-scaleup`, `sap-hana-scaleout`, and `sap-hana-ha`.