### PR TITLE
Update path in image build

### DIFF
--- a/images/awx/preinstall.yml
+++ b/images/awx/preinstall.yml
@@ -40,7 +40,7 @@
       - '{{ sap_iac_path }}/ansible*'
       - '{{ sap_iac_path }}/stacks'
       - '{{ sap_iac_path }}/terraform'
-      - '{{ sap_iac_path }}/vendor'
+      - '{{ sap_iac_path }}/third_party'
       dest: '{{ playbook_dir }}/sap-iac.tar.gz'
       format: gz
     register: archive_sap_iac


### PR DESCRIPTION
The AWX image should have the third_party included instead of vendor.
Previously it was vendor but has been changed since moving the code to
GitHub.