### PR TITLE
Fix storage to work with any role

### DIFF
--- a/ansible/roles/sap-hana-scaleout-standby/defaults/main.yml
+++ b/ansible/roles/sap-hana-scaleout-standby/defaults/main.yml
@@ -52,7 +52,6 @@ sap_hana_ini_setting: basepath_shared
 sap_hana_ini_value: "no"
 sap_hana_system_restart: "n"
 sap_hana_gce_storage_client_path: '{{ sap_hana_shared_mountpoint }}/gceStorageClient'
-sap_hana_stack_name: 'hana-scaleout-standby'
 # sap_hana_password is required unless all of the other passwords are set.
 # It defaults to an empty string for those cases where all the other passwords are
 # set, to avoid an undefined variable error.
@@ -77,11 +76,13 @@ sap_hana_logvols:
     vol: "{{ sap_hana_data_partition_name }}"
     mountpoint: "{{ sap_hana_data_mountpoint }}"
     fstype: xfs
+    mount: false
   log:
     size: "{{ sap_hana_log_size }}"
     vol: "{{ sap_hana_data_partition_name }}"
     mountpoint: "{{ sap_hana_log_mountpoint }}"
     fstype: xfs
+    mount: false
 
 sap_hana_disks_worker:
   - { name: data, partition_path : "{{ sap_hana_data_partition_name }}"}
@@ -91,11 +92,13 @@ sap_hana_logvols_worker:
     vol: "{{ sap_hana_data_partition_name }}"
     mountpoint: "{{ sap_hana_data_mountpoint }}"
     fstype: xfs
+    mount: false
   log:
     size: "{{ sap_hana_log_size }}"
     vol: "{{ sap_hana_data_partition_name }}"
     mountpoint: "{{ sap_hana_log_mountpoint }}"
     fstype: xfs
+    mount: false
 
 sap_hana_disks_standby:
   - { name: data, partition_path : "{{ sap_hana_data_partition_name }}"}
@@ -105,11 +108,13 @@ sap_hana_logvols_standby:
     vol: "{{ sap_hana_data_partition_name }}"
     mountpoint: "{{ sap_hana_data_mountpoint }}"
     fstype: xfs
+    mount: false
   log:
     size: "{{ sap_hana_log_size }}"
     vol: "{{ sap_hana_data_partition_name }}"
     mountpoint: "{{ sap_hana_log_mountpoint }}"
     fstype: xfs
+    mount: false
 
 # Hana install vars
 sap_hana_deployment_hdblcm_extraargs:

--- a/ansible/roles/storage/tasks/main.yml
+++ b/ansible/roles/storage/tasks/main.yml
@@ -88,10 +88,10 @@
     opts: defaults
     src: "/dev/{{ item.value.vol }}/{{ item.key }}"
     state: mounted
-  with_dict: "{{ logvols }}"
+  with_dict: "{{ logvols | default({}) }}"
   tags:
     - disk_setup
-  when: (logvols is defined) and (sap_hana_stack_name != 'hana-scaleout-standby')
+  when: item.value.mount | default(true)
 
 - name: Swap on
   block:


### PR DESCRIPTION
The variable `sap_hana_stack_name` is only defined in the `hana-scaleout-standby`
role, so other roles using `storage` get an error. This replaces the variable
with a `mount` attribute for logical volumes (defaulting to `true`), this way it
can work with any role, including non-HANA related ones.