### PR TITLE
Add support for web dispatcher and gateway on ASCS

### DIFF
--- a/ansible/roles/ascs/templates/inifile.params.j2
+++ b/ansible/roles/ascs/templates/inifile.params.j2
@@ -65,7 +65,22 @@ NW_GetSidNoProfiles.unicode = true
 NW_getFQDN.setFQDN = false
 
 # Add gateway process in the ASCS instance
-# NW_SCS_Instance.ascsInstallGateway = false
+NW_SCS_Instance.ascsInstallGateway = {{ sap_nw_ascs_install_gateway | default('false') | lower }}
 
 # Add Web Dispatcher process in the ASCS instance
-# NW_SCS_Instance.ascsInstallWebDispatcher = false
+NW_SCS_Instance.ascsInstallWebDispatcher = {{ sap_nw_ascs_install_web_dispatcher | default('false') | lower }}
+
+# There are three types of encryption modes: 'Always' (default), 'depending on the incoming protocol', 'Never'
+NW_webdispatcher_Instance.encryptionMode = {{ sap_nw_wd_encryption_mode | default('Always') }}
+
+# Operating systems have restrictions for maximum number of open 'file handles' (sockets) for each process. Default is 2048. Provide a much higher value for  scenarios with heavy workload.
+NW_webdispatcher_Instance.scenarioSize = {{ sap_nw_wd_scenario_size | default('2048') }}
+
+# Set this parameter to 'true' if the SAP Web Dispatcher HTTP Port is to be used.
+NW_webdispatcher_Instance.useWdHTTPPort = {{ sap_nw_wd_use_http | default('true') | lower }}
+
+# HTTP Port of SAP Web Dispatcher. You can only specify this parameter if 'NW_webdispatcher_Instance.useWdHTTPPort' is set to 'true'.
+NW_webdispatcher_Instance.wdHTTPPort = {{ sap_nw_wd_http_port | default('8000') }}
+
+# HTTPS Port of SAP Web Dispatcher.
+NW_webdispatcher_Instance.wdHTTPSPort = {{ sap_nw_wd_https_port | default('44300') }}

--- a/ansible/roles/netweaver-ha/tasks/assertions.yml
+++ b/ansible/roles/netweaver-ha/tasks/assertions.yml
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: define optional processes
+  set_fact:
+    sap_nw_gw_proc: '{{ "GATEWAY|" if sap_nw_ascs_install_gateway | bool else "" }}'
+    sap_nw_wd_proc: '{{ "|WEBDISP" if sap_nw_ascs_install_web_dispatcher | bool else "" }}'
+
 - name: define pacemaker expected status for redhat
   set_fact:
     # sap-assertions role requires sap_expected_pacemaker_status variable
@@ -62,8 +67,8 @@
     - '{{ "enserver, EnqueueServer, GREEN, Running" if sap_product_vars[sap_product_and_version].ensa_version == "1" else "enq_server, Enqueue Server 2, GREEN, Running" }}'
     sap_instances:
     - '{{ sap_nw_pas_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, ABAP|GATEWAY|ICMAN|IGS, GREEN'
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GRAY'
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, {{ sap_nw_gw_proc }}MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GRAY'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, {{ sap_nw_gw_proc }}MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_ers_virtual_host }}, {{ sap_nw_ers_instance_number | int }}, 5{{ sap_nw_ers_instance_number }}13, 5{{ sap_nw_ers_instance_number }}14, 0.5, ENQREP, GRAY'
     - '{{ sap_nw_ers_virtual_host }}, {{ sap_nw_ers_instance_number | int }}, 5{{ sap_nw_ers_instance_number }}13, 5{{ sap_nw_ers_instance_number }}14, 0.5, ENQREP, GREEN'
     sap_instance_number: '{{ sap_nw_ascs_instance_number }}'
@@ -83,8 +88,8 @@
     - gwrd, Gateway, GREEN, Running
     sap_instances:
     - '{{ sap_nw_pas_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, J2EE|IGS, GREEN'
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE, GRAY'
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GRAY'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_ers_virtual_host }}, {{ sap_nw_ers_instance_number | int }}, 5{{ sap_nw_ers_instance_number }}13, 5{{ sap_nw_ers_instance_number }}14, 0.5, ENQREP, GRAY'
     - '{{ sap_nw_ers_virtual_host }}, {{ sap_nw_ers_instance_number | int }}, 5{{ sap_nw_ers_instance_number }}13, 5{{ sap_nw_ers_instance_number }}14, 0.5, ENQREP, GREEN'
     sap_instance_number: '{{ sap_nw_ascs_instance_number }}'
@@ -102,8 +107,8 @@
     - '{{ "enrepserver, EnqueueReplicator, GREEN, Running" if sap_product_vars[sap_product_and_version].ensa_version == "1" else "enq_replicator, Enqueue Replicator 2, GREEN, Running" }}'
     sap_instances:
     - '{{ sap_nw_pas_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, ABAP|GATEWAY|ICMAN|IGS, GREEN'
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GRAY'
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, {{ sap_nw_gw_proc }}MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GRAY'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, {{ sap_nw_gw_proc }}MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_ers_virtual_host }}, {{ sap_nw_ers_instance_number | int }}, 5{{ sap_nw_ers_instance_number }}13, 5{{ sap_nw_ers_instance_number }}14, 0.5, ENQREP, GRAY'
     - '{{ sap_nw_ers_virtual_host }}, {{ sap_nw_ers_instance_number | int }}, 5{{ sap_nw_ers_instance_number }}13, 5{{ sap_nw_ers_instance_number }}14, 0.5, ENQREP, GREEN'
     sap_instance_number: '{{ sap_nw_ers_instance_number }}'
@@ -121,8 +126,8 @@
     - '{{ "enrepserver, EnqueueReplicator, GREEN, Running" if sap_product_vars[sap_product_and_version].ensa_version == "1" else "enq_replicator, Enqueue Replicator 2, GREEN, Running" }}'
     sap_instances:
     - '{{ sap_nw_pas_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, J2EE|IGS, GREEN'
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE, GRAY'
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GRAY'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_ers_virtual_host }}, {{ sap_nw_ers_instance_number | int }}, 5{{ sap_nw_ers_instance_number }}13, 5{{ sap_nw_ers_instance_number }}14, 0.5, ENQREP, GRAY'
     - '{{ sap_nw_ers_virtual_host }}, {{ sap_nw_ers_instance_number | int }}, 5{{ sap_nw_ers_instance_number }}13, 5{{ sap_nw_ers_instance_number }}14, 0.5, ENQREP, GREEN'
     sap_instance_number: '{{ sap_nw_ers_instance_number }}'
@@ -143,8 +148,8 @@
     - icman, ICM, GREEN, Running
     sap_instances:
     - '{{ sap_nw_pas_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, ABAP|GATEWAY|ICMAN|IGS, GREEN'
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GRAY'
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GRAY'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_ers_virtual_host }}, {{ sap_nw_ers_instance_number | int }}, 5{{ sap_nw_ers_instance_number }}13, 5{{ sap_nw_ers_instance_number }}14, 0.5, ENQREP, GRAY'
     - '{{ sap_nw_ers_virtual_host }}, {{ sap_nw_ers_instance_number | int }}, 5{{ sap_nw_ers_instance_number }}13, 5{{ sap_nw_ers_instance_number }}14, 0.5, ENQREP, GREEN'
     sap_instance_number: '{{ sap_nw_pas_instance_number }}'
@@ -162,8 +167,8 @@
     - igswd_mt, IGS Watchdog, GREEN, Running
     sap_instances:
     - '{{ sap_nw_pas_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, J2EE|IGS, GREEN'
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE, GRAY'
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GRAY'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_ers_virtual_host }}, {{ sap_nw_ers_instance_number | int }}, 5{{ sap_nw_ers_instance_number }}13, 5{{ sap_nw_ers_instance_number }}14, 0.5, ENQREP, GRAY'
     - '{{ sap_nw_ers_virtual_host }}, {{ sap_nw_ers_instance_number | int }}, 5{{ sap_nw_ers_instance_number }}13, 5{{ sap_nw_ers_instance_number }}14, 0.5, ENQREP, GREEN'
     sap_instance_number: '{{ sap_nw_pas_instance_number }}'

--- a/ansible/roles/nw-db2-distributed/tasks/assertions.yml
+++ b/ansible/roles/nw-db2-distributed/tasks/assertions.yml
@@ -21,7 +21,7 @@
     - msg_server, MessageServer, GREEN, Running
     - '{{ "enserver, EnqueueServer, GREEN, Running" if sap_product_vars[sap_nw_product_and_version].ensa_version == "1" else "enq_server, Enqueue Server 2, GREEN, Running" }}'
     sap_instances:
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_pas_virtual_host }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, ABAP|GATEWAY|ICMAN|IGS, GREEN'
     sap_instance_number: '{{ sap_nw_ascs_instance_number }}'
   when: ansible_hostname == sap_nw_ascs_virtual_host
@@ -37,7 +37,7 @@
     - gwrd, Gateway, GREEN, Running
     - icman, ICM, GREEN, Running
     sap_instances:
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_pas_virtual_host }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, ABAP|GATEWAY|ICMAN|IGS, GREEN'
     sap_instance_number: '{{ sap_nw_pas_instance_number }}'
   when: ansible_hostname == sap_nw_pas_virtual_host

--- a/ansible/roles/nw-distributed/tasks/assertions.yml
+++ b/ansible/roles/nw-distributed/tasks/assertions.yml
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: define optional processes
+  set_fact:
+    sap_nw_gw_proc: '{{ "GATEWAY|" if sap_nw_ascs_install_gateway | bool else "" }}'
+    sap_nw_wd_proc: '{{ "|WEBDISP" if sap_nw_ascs_install_web_dispatcher | bool else "" }}'
+
 - name: include sap assertions role for ascs abap
   include_role:
     name: sap-assertions
@@ -21,7 +26,7 @@
     - msg_server, MessageServer, GREEN, Running
     - '{{ "enserver, EnqueueServer, GREEN, Running" if sap_product_vars[sap_product_and_version].ensa_version == "1" else "enq_server, Enqueue Server 2, GREEN, Running" }}'
     sap_instances:
-    - '{{ sap_nw_ascs_instance_name }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_ascs_instance_name }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, {{ sap_nw_gw_proc }}MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_pas_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, ABAP|GATEWAY|ICMAN|IGS, GREEN'
     sap_instance_number: '{{ sap_nw_ascs_instance_number }}'
   when:
@@ -37,7 +42,7 @@
     - msg_server, MessageServer, GREEN, Running
     - '{{ "enserver, EnqueueServer, GREEN, Running" if sap_product_vars[sap_product_and_version].ensa_version == "1" else "enq_server, Enqueue Server 2, GREEN, Running" }}'
     sap_instances:
-    - '{{ sap_nw_ascs_instance_name }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_ascs_instance_name }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_pas_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, J2EE|IGS, GREEN'
     sap_instance_number: '{{ sap_nw_ascs_instance_number }}'
   when:
@@ -55,7 +60,7 @@
     - gwrd, Gateway, GREEN, Running
     - icman, ICM, GREEN, Running
     sap_instances:
-    - '{{ sap_nw_ascs_instance_name }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_ascs_instance_name }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, {{ sap_nw_gw_proc }}MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_pas_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, ABAP|GATEWAY|ICMAN|IGS, GREEN'
     sap_instance_number: '{{ sap_nw_pas_instance_number }}'
   when:
@@ -71,7 +76,7 @@
     - jstart, J2EE Server, GREEN, All processes running
     - igswd_mt, IGS Watchdog, GREEN, Running
     sap_instances:
-    - '{{ sap_nw_ascs_instance_name }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_ascs_instance_name }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_pas_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, J2EE|IGS, GREEN'
     sap_instance_number: '{{ sap_nw_pas_instance_number }}'
   when:

--- a/ansible/roles/nw-standard/tasks/assertions.yml
+++ b/ansible/roles/nw-standard/tasks/assertions.yml
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: define optional processes
+  set_fact:
+    sap_nw_gw_proc: '{{ "GATEWAY|" if sap_nw_ascs_install_gateway | bool else "" }}'
+    sap_nw_wd_proc: '{{ "|WEBDISP" if sap_nw_ascs_install_web_dispatcher | bool else "" }}'
+
 - name: include sap assertions role for ascs abap
   include_role:
     name: sap-assertions
@@ -21,7 +26,7 @@
     - msg_server, MessageServer, GREEN, Running
     - '{{ "enserver, EnqueueServer, GREEN, Running" if sap_product_vars[sap_product_and_version].ensa_version == "1" else "enq_server, Enqueue Server 2, GREEN, Running" }}'
     sap_instances:
-    - '{{ sap_nw_instance_name }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_instance_name }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, {{ sap_nw_gw_proc }}MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, ABAP|GATEWAY|ICMAN|IGS, GREEN'
     sap_instance_number: '{{ sap_nw_ascs_instance_number }}'
   when: sap_scs_name == 'ASCS'
@@ -49,7 +54,7 @@
     - msg_server, MessageServer, GREEN, Running
     - '{{ "enserver, EnqueueServer, GREEN, Running" if sap_product_vars[sap_product_and_version].ensa_version == "1" else "enq_server, Enqueue Server 2, GREEN, Running" }}'
     sap_instances:
-    - '{{ sap_nw_instance_name }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_instance_name }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, J2EE|IGS, GREEN'
     sap_instance_number: '{{ sap_nw_ascs_instance_number }}'
   when: sap_scs_name == 'SCS'

--- a/ansible/roles/nw/templates/inifile.params.j2
+++ b/ansible/roles/nw/templates/inifile.params.j2
@@ -55,10 +55,25 @@ SAPINST.CD.PACKAGE.RDBMS = {{ sap_nw_rdbms_files }}
 # NW_ABAP_SSFS_CustomKey.ssfsKeyInputFile =
 
 # Standard system only: Add gateway process to (A)SCS instance
-# NW_CI_Instance.ascsInstallGateway = false
+NW_CI_Instance.ascsInstallGateway = {{ sap_nw_ascs_install_gateway | default('false') | lower }}
 
 # Standard system only: Add web dispatcher process to (A)SCS instance
-# NW_CI_Instance.ascsInstallWebDispatcher = false
+NW_CI_Instance.ascsInstallWebDispatcher = {{ sap_nw_ascs_install_web_dispatcher | default('false') | lower }}
+
+# There are three types of encryption modes: 'Always' (default), 'depending on the incoming protocol', 'Never'
+NW_webdispatcher_Instance.encryptionMode = {{ sap_nw_wd_encryption_mode | default('Always') }}
+
+# Operating systems have restrictions for maximum number of open 'file handles' (sockets) for each process. Default is 2048. Provide a much higher value for  scenarios with heavy workload.
+NW_webdispatcher_Instance.scenarioSize = {{ sap_nw_wd_scenario_size | default('2048') }}
+
+# Set this parameter to 'true' if the SAP Web Dispatcher HTTP Port is to be used.
+NW_webdispatcher_Instance.useWdHTTPPort = {{ sap_nw_wd_use_http | default('true') | lower }}
+
+# HTTP Port of SAP Web Dispatcher. You can only specify this parameter if 'NW_webdispatcher_Instance.useWdHTTPPort' is set to 'true'.
+NW_webdispatcher_Instance.wdHTTPPort = {{ sap_nw_wd_http_port | default('8000') }}
+
+# HTTPS Port of SAP Web Dispatcher.
+NW_webdispatcher_Instance.wdHTTPSPort = {{ sap_nw_wd_https_port | default('44300') }}
 
 # Standard system with AS ABAP only: ASCS instance number. Leave empty for default.
 NW_CI_Instance.ascsInstanceNumber = {{ sap_nw_ascs_instance_number }}

--- a/ansible/roles/nw/templates/inifile_java.params.j2
+++ b/ansible/roles/nw/templates/inifile_java.params.j2
@@ -30,7 +30,22 @@ HDB_Schema_Check_Dialogs.schemaPassword = {{ sap_nw_password }}
 # NW_CI_Instance.ascsInstallGateway = false
 
 # Standard system only: Add web dispatcher process to (A)SCS instance
-# NW_CI_Instance.ascsInstallWebDispatcher = false
+NW_CI_Instance.ascsInstallWebDispatcher = {{ sap_nw_ascs_install_web_dispatcher | default('false') | lower }}
+
+# There are three types of encryption modes: 'Always' (default), 'depending on the incoming protocol', 'Never'
+NW_webdispatcher_Instance.encryptionMode = {{ sap_nw_wd_encryption_mode | default('Always') }}
+
+# Operating systems have restrictions for maximum number of open 'file handles' (sockets) for each process. Default is 2048. Provide a much higher value for  scenarios with heavy workload.
+NW_webdispatcher_Instance.scenarioSize = {{ sap_nw_wd_scenario_size | default('2048') }}
+
+# Set this parameter to 'true' if the SAP Web Dispatcher HTTP Port is to be used.
+NW_webdispatcher_Instance.useWdHTTPPort = {{ sap_nw_wd_use_http | default('true') | lower }}
+
+# HTTP Port of SAP Web Dispatcher. You can only specify this parameter if 'NW_webdispatcher_Instance.useWdHTTPPort' is set to 'true'.
+NW_webdispatcher_Instance.wdHTTPPort = {{ sap_nw_wd_http_port | default('8000') }}
+
+# HTTPS Port of SAP Web Dispatcher.
+NW_webdispatcher_Instance.wdHTTPSPort = {{ sap_nw_wd_https_port | default('44300') }}
 
 # Standard system with AS ABAP only: ASCS instance number. Leave empty for default.
 # NW_CI_Instance.ascsInstanceNumber =


### PR DESCRIPTION
This adds variables `sap_nw_ascs_install_gateway` and
`sap_nw_ascs_install_web_dispatcher`, which will enable the installation of
the gateway and/or web dispatcher during ASCS installation.