### PR TITLE
Add "no Terraform" playbooks to stack directories

### DIFF
--- a/ansible/roles/nw-distributed/defaults/main.yml
+++ b/ansible/roles/nw-distributed/defaults/main.yml
@@ -15,6 +15,25 @@
 sap_is_ascs: false
 sap_is_pas: false
 
+sap_nw_ascs_instance_name: '{{
+  hostvars.values()
+  | selectattr("sap_is_ascs", "defined")
+  | selectattr("sap_is_ascs")
+  | map(attribute="ansible_hostname")
+  | list
+  | first
+}}'
+sap_nw_pas_instance_name: '{{
+  hostvars.values()
+  | selectattr("sap_is_pas", "defined")
+  | selectattr("sap_is_pas")
+  | map(attribute="ansible_hostname")
+  | list
+  | first
+}}'
+sap_nw_ascs_virtual_host: '{{ sap_nw_ascs_instance_name }}'
+sap_nw_pas_virtual_host: '{{ sap_nw_pas_instance_name }}'
+
 nfs_server_exports:
 - directory: /sapmnt
   clients: '{{
@@ -41,10 +60,13 @@ sap_nw_ascs_private_ip: '{{
   | first
 }}'
 
+sap_hana_backint_bucket_name: ''
+sap_hana_backint_install: '{{ sap_hana_backint_bucket_name | length > 0 }}'
 sap_hana_password: ''
 sap_hana_db_system_password: '{{ sap_hana_password }}'
 sap_hana_sidadm_password: '{{ sap_hana_password }}'
 sap_hana_user: '{{ sap_hana_sid | lower }}adm'
+sap_hana_virtual_host: '{{ sap_hana_instance_name }}'
 
 sap_nw_ascs_instance_number: '03'
 sap_nw_pas_instance_number: '02'

--- a/ansible/roles/nw-standard/defaults/main.yml
+++ b/ansible/roles/nw-standard/defaults/main.yml
@@ -12,13 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+sap_hana_backint_bucket_name: ''
+sap_hana_backint_install: '{{ sap_hana_backint_bucket_name | length > 0 }}'
 sap_hana_password: ''
 sap_hana_db_system_password: '{{ sap_hana_password }}'
 sap_hana_sidadm_password: '{{ sap_hana_password }}'
 sap_hana_user: '{{ sap_hana_sid | lower }}adm'
+sap_hana_virtual_host: '{{ sap_hana_instance_name }}'
 
 sap_nw_ascs_instance_number: "00"
 sap_nw_pas_instance_number: "01"
+sap_nw_ascs_virtual_host: '{{ ansible_hostname }}'
+sap_nw_pas_virtual_host: '{{ ansible_hostname }}'
 sap_nw_install_files_dest: /sapmnt/Software
 sap_nw_kernel_files: /sapmnt/Software/Kernel_Files
 sap_nw_rdbms_files: /sapmnt/Software/HANA_CLIENT

--- a/ansible/roles/sap-hana-ha/defaults/main.yml
+++ b/ansible/roles/sap-hana-ha/defaults/main.yml
@@ -12,6 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+sap_hana_primary_instance_name: '{{
+  hostvars.values()
+  | selectattr("sap_hana_is_primary", "defined")
+  | selectattr("sap_hana_is_primary")
+  | map(attribute="ansible_hostname")
+  | list
+  | first
+}}'
+sap_hana_primary_instance_ip: '{{
+  hostvars.values()
+  | selectattr("sap_hana_is_primary", "defined")
+  | selectattr("sap_hana_is_primary")
+  | map(attribute="ansible_default_ipv4.address")
+  | list
+  | first
+}}'
+sap_hana_secondary_instance_name: '{{
+  hostvars.values()
+  | selectattr("sap_hana_is_primary", "defined")
+  | selectattr("sap_hana_is_primary", "equalto", false)
+  | map(attribute="ansible_hostname")
+  | list
+  | first
+}}'
+sap_hana_secondary_instance_ip: '{{
+  hostvars.values()
+  | selectattr("sap_hana_is_primary", "defined")
+  | selectattr("sap_hana_is_primary", "equalto", false)
+  | map(attribute="ansible_default_ipv4.address")
+  | list
+  | first
+}}'
+
 sap_hana_install_files_bucket: sap-deployment-media
 sap_hana_is_primary: false
 sap_hana_product_version: 20SPS03
@@ -70,6 +103,8 @@ sap_hana_hsr_replication_mode: syncmem
 sap_hana_fast_restart: false
 
 # Backint install vars
+sap_hana_backint_bucket_name: ''
+sap_hana_backint_install: '{{ sap_hana_backint_bucket_name | length > 0 }}'
 backint_temp_path: /tmp/backint-gcs-install.sh
 backint_dir: "/usr/sap/{{ sap_hana_sid }}/SYS/global/hdb/opt/backint"
 backint_config_path: "{{ backint_dir }}/backint-gcs/parameters.txt"

--- a/ansible/roles/sap-hana-scaleout/defaults/main.yml
+++ b/ansible/roles/sap-hana-scaleout/defaults/main.yml
@@ -33,6 +33,11 @@ sap_hana_worker_node_names: '{{
   | map(attribute="ansible_hostname")
   | list
 }}'
+sap_hana_instances: '{{
+  hostvars.values()
+  | map(attribute="ansible_hostname")
+  | list
+}}'
 
 sap_hana_install_files_bucket: sap-deployment-media
 sap_hana_product_version: 20SPS03
@@ -89,6 +94,8 @@ sap_hana_sapadm_password: '{{ sap_hana_password }}'
 sap_hana_sidadm_password: '{{ sap_hana_password }}'
 
 # Backint install vars
+sap_hana_backint_bucket_name: ''
+sap_hana_backint_install: '{{ sap_hana_backint_bucket_name | length > 0 }}'
 backint_temp_path: /tmp/backint-gcs-install.sh
 backint_dir: "/usr/sap/{{ sap_hana_sid }}/SYS/global/hdb/opt/backint"
 backint_config_path: "{{ backint_dir }}/backint-gcs/parameters.txt"

--- a/ansible/roles/sap-hana-scaleup/defaults/main.yml
+++ b/ansible/roles/sap-hana-scaleup/defaults/main.yml
@@ -63,6 +63,8 @@ sap_hana_sidadm_password: '{{ sap_hana_password }}'
 sap_hana_fast_restart: false
 
 # Backint install vars
+sap_hana_backint_bucket_name: ''
+sap_hana_backint_install: '{{ sap_hana_backint_bucket_name | length > 0 }}'
 backint_temp_path: /tmp/backint-gcs-install.sh
 backint_dir: "/usr/sap/{{ sap_hana_sid }}/SYS/global/hdb/opt/backint"
 backint_config_path: "{{ backint_dir }}/backint-gcs/parameters.txt"

--- a/stacks/HANA-HA/playbook-notf.yml
+++ b/stacks/HANA-HA/playbook-notf.yml
@@ -1,0 +1,25 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: SAP HANA configure on both primary and secondary
+  hosts: hana
+  become: yes
+  tasks:
+  - include_role:
+      name: sap-hana-ha
+    tags: [hana]
+  - include_role:
+      name: sap-hana-ha
+      tasks_from: assertions
+    tags: [hana, assertions]

--- a/stacks/HANA-Scaleout/playbook-notf.yml
+++ b/stacks/HANA-Scaleout/playbook-notf.yml
@@ -1,0 +1,46 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: SAP HANA gather facts
+  hosts: hana
+  become: true
+
+- name: SAP HANA scaleout master configure
+  hosts: hana_master
+  become: true
+  roles:
+  - role: sap-hana-scaleout
+
+- name: SAP HANA scaleout worker configure
+  hosts: hana_worker
+  become: true
+  roles:
+  - role: sap-hana-scaleout
+
+- name: SAP HANA scaleout master configure
+  hosts: hana_master
+  become: true
+  vars:
+    sap_add_worker_nodes: true
+  roles:
+  - role: sap-hana-scaleout
+
+- name: Run assertions
+  hosts: hana
+  become: true
+  tasks:
+  - include_role:
+      name: sap-hana-scaleout
+      tasks_from: assertions
+  tags: [assertions]

--- a/stacks/HANA-Scaleup/playbook-notf.yml
+++ b/stacks/HANA-Scaleup/playbook-notf.yml
@@ -1,0 +1,29 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: SAP HANA deploy
+  hosts: hana
+  become: true
+  tasks:
+  - include_role:
+      name: sap-hana-scaleup
+
+- name: Run assertions
+  hosts: hana
+  become: true
+  tasks:
+  - include_role:
+      name: sap-hana-scaleup
+      tasks_from: assertions
+  tags: [assertions]

--- a/stacks/NetWeaver-Distributed/playbook-notf.yml
+++ b/stacks/NetWeaver-Distributed/playbook-notf.yml
@@ -1,0 +1,45 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: SAP HANA configure
+  hosts: hana
+  become: true
+  roles:
+  - role: sap-hana-scaleup
+  tags: [hana]
+
+- name: SAP NW configure
+  hosts: nw
+  become: true
+  roles:
+  - role: nw-distributed
+  tags: [nw]
+
+- name: Run assertions on HANA
+  hosts: hana
+  become: true
+  tasks:
+  - include_role:
+      name: sap-hana-scaleup
+      tasks_from: assertions
+  tags: [hana, assertions]
+
+- name: Run assertions on application servers
+  hosts: nw
+  become: true
+  tasks:
+  - include_role:
+      name: nw-distributed
+      tasks_from: assertions
+  tags: [nw, assertions]

--- a/stacks/NetWeaver-HA/playbook-notf.yml
+++ b/stacks/NetWeaver-HA/playbook-notf.yml
@@ -1,0 +1,45 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: SAP HANA configure
+  hosts: hana
+  become: true
+  roles:
+  - role: sap-hana-ha
+    tags: [hana]
+
+- name: SAP application configure
+  hosts: sap
+  become: true
+  roles:
+  - role: netweaver-ha
+    tags: [nw]
+
+- name: Run assertions on HANA
+  hosts: hana
+  become: true
+  tasks:
+  - include_role:
+      name: sap-hana-ha
+      tasks_from: assertions
+  tags: [hana, assertions]
+
+- name: Run assertions on application servers
+  hosts: sap
+  become: true
+  tasks:
+  - include_role:
+      name: netweaver-ha
+      tasks_from: assertions
+  tags: [nw, assertions]

--- a/stacks/NetWeaver-Standard/playbook-notf.yml
+++ b/stacks/NetWeaver-Standard/playbook-notf.yml
@@ -1,0 +1,47 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: SAP HANA configure
+  hosts: hana
+  become: true
+  roles:
+  - role: sap-hana-scaleup
+  tags: [hana]
+
+- name: SAP NetWeaver configure
+  hosts: nw
+  become: true
+  roles:
+  - role: nw-standard
+    vars:
+      sap_hana_virtual_host: '{{ sap_hana_instance_name }}'
+  tags: [nw]
+
+- name: Run assertions on HANA
+  hosts: hana
+  become: yes
+  tasks:
+  - include_role:
+      name: sap-hana-scaleup
+      tasks_from: assertions
+  tags: [hana, assertions]
+
+- name: Run assertions on application server
+  hosts: nw
+  become: yes
+  tasks:
+  - include_role:
+      name: nw-standard
+      tasks_from: assertions
+  tags: [nw, assertions]


### PR DESCRIPTION
These playbooks can be used without Terraform or when Terraform is run
separately from Ansible.