### PR TITLE
Update nw-standard to use sapinst role

### DIFF
--- a/ansible/roles/nw-standard/defaults/main.yml
+++ b/ansible/roles/nw-standard/defaults/main.yml
@@ -29,14 +29,14 @@ sap_nw_kernel_files: /sapmnt/Software/Kernel_Files
 sap_nw_rdbms_files: /sapmnt/Software/HANA_CLIENT
 sap_nw_user: '{{ sap_nw_sid | lower }}adm'
 
-sap_scs_name: '{{ sap_product_vars[sap_product_and_version].scs_name | default("ASCS") }}'
+sap_scs_name: '{{ sap_product_vars[sap_nw_product_and_version].scs_name | default("ASCS") }}'
 
 sap_nw_ascs_install_gateway: false
 sap_nw_ascs_install_web_dispatcher: false
 
 sap_nw_product: 'NetWeaver'
 sap_nw_product_version: '750'
-sap_product_and_version: '{{ sap_nw_product }}/{{ sap_nw_product_version }}'
+sap_nw_product_and_version: '{{ sap_nw_product }}/{{ sap_nw_product_version }}'
 # sap_nw_product and sap_nw_product_version must be set to one of the <product>/<version> combos in sap_product_vars.
 sap_product_vars:
   'BW4HANA/20':
@@ -70,7 +70,7 @@ sap_product_vars:
     install_files: [HANA_CLIENT, Kernel_Files, NW75, SWPM10SP32]
     ensa_version: '1'
     scs_name: 'SCS'
-    onehost_sapinst_template: inifile_java.params.j2
+    onehost_sapinst_template: inifile_onehost_java_hdb.params
   'S4HANA/1709':
     onehost_product_id: 'NW_ABAP_OneHost:S4HANA1709.CORE.HDB.ABAP'
     swpm_path: /sapmnt/Software/SWPM1.0

--- a/ansible/roles/nw-standard/tasks/assertions.yml
+++ b/ansible/roles/nw-standard/tasks/assertions.yml
@@ -24,7 +24,7 @@
     sap_become_user: '{{ sap_nw_user }}'
     sap_expected_processes:
     - msg_server, MessageServer, GREEN, Running
-    - '{{ "enserver, EnqueueServer, GREEN, Running" if sap_product_vars[sap_product_and_version].ensa_version == "1" else "enq_server, Enqueue Server 2, GREEN, Running" }}'
+    - '{{ "enserver, EnqueueServer, GREEN, Running" if sap_product_vars[sap_nw_product_and_version].ensa_version == "1" else "enq_server, Enqueue Server 2, GREEN, Running" }}'
     sap_instances:
     - '{{ sap_nw_instance_name }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, {{ sap_nw_gw_proc }}MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, ABAP|GATEWAY|ICMAN|IGS, GREEN'
@@ -52,7 +52,7 @@
     sap_become_user: '{{ sap_nw_user }}'
     sap_expected_processes:
     - msg_server, MessageServer, GREEN, Running
-    - '{{ "enserver, EnqueueServer, GREEN, Running" if sap_product_vars[sap_product_and_version].ensa_version == "1" else "enq_server, Enqueue Server 2, GREEN, Running" }}'
+    - '{{ "enserver, EnqueueServer, GREEN, Running" if sap_product_vars[sap_nw_product_and_version].ensa_version == "1" else "enq_server, Enqueue Server 2, GREEN, Running" }}'
     sap_instances:
     - '{{ sap_nw_instance_name }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, GATEWAY|MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, J2EE|IGS, GREEN'

--- a/ansible/roles/nw-standard/tasks/main.yml
+++ b/ansible/roles/nw-standard/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: ensure that a known product version is defined
   assert:
-    that: sap_product_and_version in sap_product_vars
+    that: sap_nw_product_and_version in sap_product_vars
     fail_msg: 'sap_nw_product and sap_nw_product_version must match one of {{ sap_product_vars.keys() | join(", ") }}'
 
 - name: include base role
@@ -48,10 +48,13 @@
 - name: include nw-pre role
   include_role:
     name: nw-pre
-
-- name: include nw role
-  include_role:
-    name: nw
   vars:
-    sap_nw_product_id: '{{ sap_product_vars[sap_product_and_version].onehost_product_id }}'
-    sap_sapinst_template: "{{ sap_product_vars[sap_product_and_version].onehost_sapinst_template | default('inifile.params.j2') }}"
+    sap_product_and_version: '{{ sap_nw_product_and_version }}'
+
+- name: include sapinst role
+  include_role:
+    name: sapinst
+  vars:
+    sap_product_id: '{{ sap_product_vars[sap_nw_product_and_version].onehost_product_id }}'
+    sap_sapinst_swpm_path: '{{ sap_product_vars[sap_nw_product_and_version].swpm_path }}'
+    sap_sapinst_template: '{{ sap_product_vars[sap_nw_product_and_version].onehost_sapinst_template | default("inifile_onehost_hdb.params") }}'

--- a/ansible/roles/sapinst/templates/inifile_onehost_hdb.params.j2
+++ b/ansible/roles/sapinst/templates/inifile_onehost_hdb.params.j2
@@ -1,0 +1,348 @@
+# {{ ansible_managed }}
+
+# Password for the Diagnostics Agent specific <dasid>adm user. Provided value may be encoded.
+# DiagnosticsAgent.dasidAdmPassword =
+
+# Windows domain in which the Diagnostics Agent users must be created. This is an optional property (Windows only).
+# DiagnosticsAgent.domain =
+
+# Windows only: Password for the Diagnostics Agent specific 'SAPService<DASID>' user.
+# DiagnosticsAgent.sapServiceDASIDPassword =
+
+# Specify whether Software Provisioning Manager is to drop the schema if it exists.
+# HDB_Schema_Check_Dialogs.dropSchema = false
+
+# The name of the database schema.
+# HDB_Schema_Check_Dialogs.schemaName = SAPHANADB
+
+# The password of the database schema.
+HDB_Schema_Check_Dialogs.schemaPassword = {{ sap_nw_password }}
+
+# Specify whether Software Provisioning Manager is to validate the schema name. The schema name must only contain numbers and capital letters. It  must not start with '_' . It cannot be 'SYS' or 'SYSTEM'.
+# HDB_Schema_Check_Dialogs.validateSchemaName = true
+
+# Use SAP HANA Media on CD, do not ask for SAR archives
+# HDB_Software_Dialogs.useMediaCD = false
+
+# Database hostnames that will be set directly in hdbuserstore without resolving them in HANA. Comma separated. Example (host1,host2)
+# HDB_Userstore.doNotResolveHostnames =
+
+# Alternative port for SystemDB to be used in hdbuserstore
+# HDB_Userstore.systemDBPort =
+
+# Use ABAP secure store instead of HANA userstore. Default: false for HANA user store.
+# HDB_Userstore.useABAPSSFS = false
+
+# If set to 'true', an 'ms_acl_info' file is created. It manages the hosts from which the Message Server accepts connections.
+# MessageServer.configureAclInfo = false
+
+# Location of the input file for the 'ABAP SecureStore' key. The input file must have two lines: 'key = <key>', 'key-id = <key ID>'. You can generate a key using 'rsecssfx'. Leave empty if you want to use the default key.
+# NW_ABAP_SSFS_CustomKey.ssfsKeyInputFile =
+
+# Standard system only: Add gateway process to (A)SCS instance
+NW_CI_Instance.ascsInstallGateway = {{ sap_nw_ascs_install_gateway | lower }}
+
+# Standard system only: Add web dispatcher process to (A)SCS instance
+NW_CI_Instance.ascsInstallWebDispatcher = {{ sap_nw_ascs_install_web_dispatcher | lower }}
+
+# Standard system with AS ABAP only: ASCS instance number. Leave empty for default.
+NW_CI_Instance.ascsInstanceNumber = {{ sap_nw_ascs_instance_number }}
+
+# Standard system with AS ABAP only: Virtual host name for the ASCS instance. Leave empty for default.
+NW_CI_Instance.ascsVirtualHostname = {{ sap_nw_ascs_virtual_host }}
+
+# Instance number of the primary application server instance. Leave empty for default.
+NW_CI_Instance.ciInstanceNumber = {{ sap_nw_pas_instance_number }}
+
+# The instance number of the application server. Leave empty for default.
+NW_AS.instanceNumber = {{ sap_nw_pas_instance_number }}
+
+# The ABAP message server port. Leave empty for default.
+# NW_CI_Instance.ciMSPort =
+
+# The internal ABAP message server port. Leave empty for default.
+# NW_CI_Instance.ciMSPortInternal =
+
+# Virtual host name of the primary application server instance . Leave empty for default.
+NW_CI_Instance.ciVirtualHostname = {{ sap_nw_pas_virtual_host }}
+
+# Create file 'prxyinfo(.DAT)' in the global directory, if it does not already exist and set 'gw/prxy_info' in the default profile accordingly.  Default is 'false'.
+# NW_CI_Instance.createGlobalProxyInfoFile = false
+
+# Create file 'reginfo(.DAT)' in the global directory. Default is 'false'.
+# NW_CI_Instance.createGlobalRegInfoFile = false
+
+# User-defined number of Java server nodes. Depends on NW_CI_Instance.nodesNumber.
+# NW_CI_Instance.nodesNum =
+
+# Number of Java server nodes. Possible values: 'defNodes' - default number; 'srcNodes' - copy from source; 'userNodes' - user-defined number. Default is 'defNodes'
+# NW_CI_Instance.nodesNumber = defNodes
+
+# Standard system with AS Java only: The SCS instance number. Leave empty for default.
+# NW_CI_Instance.scsInstanceNumber =
+
+# The internal Java message server port. Leave empty for default.
+# NW_CI_Instance.scsMSPortInternal =
+
+# Standard system with AS Java only: Virtual host name for the SCS instance. Leave empty for default.
+NW_CI_Instance.scsVirtualHostname = {{ sap_nw_ascs_virtual_host }}
+
+# Activate ICF node '/SAP/BC/REST/SLPROTOCOL'
+# NW_CI_Instance_ABAP_Reports.enableActivateICFService = false
+
+# SAP INTERNAL USE ONLY
+# NW_CI_Instance_ABAP_Reports.enableSPAMUpdateWithoutStackXml = false
+
+# SAP INTERNAL USE ONLY
+# NW_CI_Instance_ABAP_Reports.enableTMSConfigWithoutStackXml = false
+
+# SAP INTERNAL USE ONLY
+# NW_CI_Instance_ABAP_Reports.enableTransportsWithoutStackXml = false
+
+# System copy AS Java with product instance Process Integration and/or Development Infrastructure: Specify whether the target system should replace the source system. Possible values are  'true' or 'false'.
+# NW_CreateDBandLoad.movePVCforUsagePiAndDi =
+
+# Password of the DDIC user in client 000
+# NW_DDIC_Password.ddic000Password =
+
+# Password of the DDIC user in client 001
+# NW_DDIC_Password.ddic001Password =
+
+# Are the passwords for the DDIC users different from the default value? Possible values are 'true' or 'false'. Leave empty for default.
+NW_DDIC_Password.needDDICPasswords = false
+
+# Specify whether the all operating system users are to be removed from group 'sapinst' after the execution of Software Provisioning Manager has completed.
+# NW_Delete_Sapinst_Users.removeUsers = false
+
+# Master password
+NW_GetMasterPassword.masterPwd = {{ sap_nw_password }}
+
+# Human readable form of the default login language to be preselected in SAPGUI. This Parameter is potentialy prompted in addition in the screen that also asks for the <SAPSID>. It is only prompted in systems that have an ABAP stack. It is prompted for installation but not for system copy. It is asked in those installations, that perform the ABAP load. That could be the database load installation in case of a distributed system szenario, or in case of a standard system installation with all instances on one host. This Parameter is saved in the 'DEFAULT' profile. It is has no influence on language settings in a Java stack. Valid names are stored in a table of subcomponent 'NW_languagesInLoadChecks'. The available languages must be declaired in the 'LANGUAGES_IN_LOAD' parameter of the 'product.xml' file . In this file, the one-character representation of the languages is used. Check the same table in subcomponent 'NW_languagesInLoadChecks'.
+# NW_GetSidNoProfiles.SAP_GUI_DEFAULT_LANGUAGE =
+
+# Windows only: The drive to use
+# NW_GetSidNoProfiles.sapdrive =
+
+# Unix only: The SAP mount directory path. Default value is '/sapmnt'.
+# NW_GetSidNoProfiles.sapmnt = /sapmnt
+
+# The SAP system ID <SAPSID> of the system to be installed
+NW_GetSidNoProfiles.sid = {{ sap_nw_sid }}
+
+# Only use this parameter if recommended by SAP.
+# NW_GetSidNoProfiles.strictSidCheck = true
+
+# Specify whether this system is to be a Unicode system.
+# NW_GetSidNoProfiles.unicode = true
+
+# ABAP schema name
+# NW_HDB_DB.abapSchemaName =
+
+# Password of the ABAP schema user
+NW_HDB_DB.abapschemaPassword = {{ sap_nw_password }}
+
+# JAVA schema name
+# NW_HDB_DB.javaSchemaName =
+
+# Password of the JAVA schema user
+# NW_HDB_DB.javaSchemaPassword =
+
+# Skip checking if creating a HANA user store is needed. Default value is 'true'. If set to 'false', a valid HANA userstore must exists.
+# NW_HDB_DBClient.checkCreateUserstore = true
+
+# Install the SAP HANA database client in a central or local directory. Possible values are: 'SAPCPE', 'LOCAL'
+# NW_HDB_DBClient.clientPathStrategy = LOCAL
+
+# Database host
+NW_HDB_getDBInfo.dbhost = {{ sap_hana_virtual_host }}
+
+# Database system ID
+NW_HDB_getDBInfo.dbsid = {{ sap_hana_sid }}
+
+# The instance number of the SAP HANA database server
+NW_HDB_getDBInfo.instanceNumber = {{ sap_hana_instance_number }}
+
+# Password of user 'SYSTEM' within the 'SystemDB' tenant in an SAP HANA MultiDB server
+NW_HDB_getDBInfo.systemDbPassword = {{ sap_hana_db_system_password }}
+
+# Password of user 'SYSTEM' inside the SAP HANA database server
+NW_HDB_getDBInfo.systemPassword = {{ sap_hana_db_system_password }}
+
+# Password of user 'SYSTEM' inside the SAP HANA database server from a backup
+# NW_HDB_getDBInfo.systemPasswordBackup =
+
+# SAP HANA system ID
+NW_HDB_getDBInfo.systemid = {{ sap_hana_sid }}
+
+# A dedicated OS group for the tenant database, required for SAP HANA multitenant database containers with high isolation level.
+# NW_HDB_getDBInfo.tenantOsGroup =
+
+# A dedicated OS user for the tenant database, required for SAP HANA multitenant database containers with high isolation level.
+# NW_HDB_getDBInfo.tenantOsUser =
+
+# Connect using SSL/TLS. Default value: false.
+# NW_HDB_getDBInfo.usingSSL = false
+
+# Location for HANA backup files on the HANA database host (as delivered by SAP).
+# NW_Recovery_Install_HDB.backupLocationHANA =
+
+# Location for HANA backup files on the SAP Application Server host.
+# NW_Recovery_Install_HDB.backupLocationSAP =
+
+# NW_Recovery_Install_HDB.checkIntegrity = false
+
+# Location for HANA backup files on the HANA database host (Target location for ABAP export archives). Default value: /usr/sap/<SID>/HDB<nn>/backup/data/<Database_name>
+NW_Recovery_Install_HDB.extractLocation = /usr/sap/{{ sap_hana_sid }}/HDB{{ sap_hana_instance_number }}/backup/data/DB_{{ sap_hana_sid }}
+
+# Number of concurrent jobs used to load and/or extract archives to HANA Host
+NW_Recovery_Install_HDB.extractParallelJobs = 24
+
+# Archives or backup files are to be loaded by SWPM or are already available(mounted) on the HANA host. Possible values are: load (default) or mount.
+# NW_Recovery_Install_HDB.loadOrMount = load
+
+# The OS user of the HANA '<dbsid>adm' user
+NW_Recovery_Install_HDB.sidAdmName = {{ sap_hana_user }}
+
+# The password of the OS HANA '<dbsid>adm' user
+NW_Recovery_Install_HDB.sidAdmPassword = {{ sap_hana_sidadm_password }}
+
+# DEPRECATED, DO NOT USE!
+# NW_SAPCrypto.SAPCryptoFile =
+
+# Enable the instance agent (sapstartsrv) data supplier to send operating system information to the System Landscape Directory (SLD). Default is 'false'.
+# NW_SLD_Configuration.configureSld = false
+
+# Host of the System Landscape Directory (SLD)
+# NW_SLD_Configuration.sldHost =
+
+# Port used to connect to the System Landscape Directory (SLD)
+# NW_SLD_Configuration.sldPort =
+
+# Use HTTPS. Default is 'false'.
+# NW_SLD_Configuration.sldUseHttps = false
+
+# The user that is to authenticate towards the System Landscape Directory (SLD)
+# NW_SLD_Configuration.sldUser =
+
+# User password to authenticate towards the System Landscape Directory (SLD). Note: The connection is not checked by Software Provisioning Manager.
+# NW_SLD_Configuration.sldUserPassword =
+
+# SAP INTERNAL USE ONLY
+# NW_System.installSAPHostAgent = true
+
+# DEPRECATED, DO NOT USE!
+# NW_Unpack.dbaToolsSar =
+
+# DEPRECATED, DO NOT USE!
+# NW_Unpack.igsExeSar =
+
+# DEPRECATED, DO NOT USE!
+# NW_Unpack.igsHelperSar =
+
+# DEPRECATED, DO NOT USE!
+# NW_Unpack.sapExeDbSar =
+
+# DEPRECATED, DO NOT USE!
+# NW_Unpack.sapExeSar =
+
+# DEPRECATED, DO NOT USE!
+# NW_Unpack.sapJvmSar =
+
+# DEPRECATED, DO NOT USE!
+# NW_Unpack.xs2Sar =
+
+# Number of Batch Work Processes. Leave empty for default.
+# NW_WPConfiguration.ciBtcWPNumber = 6
+
+# Number of Dialog Work Processes. Leave empty for default.
+# NW_WPConfiguration.ciDialogWPNumber = 10
+
+# SAP offers the option to skip setting of security profile parameters (NOT recommended) only for compatibility reasons. Set to true and the file with recommended security settings will not be taken into consideration. See SAP Note 2714839 for security recommendations.
+# NW_adaptProfile.skipSecurityProfileSettings = false
+
+# SAP INTERNAL USE ONLY
+# NW_adaptProfile.templateFiles =
+
+# The FQDN of the system
+# NW_getFQDN.FQDN =
+
+# SAP INTERNAL USE ONLY
+# NW_getFQDN.resolve = true
+
+# Specify whether you want to set FQDN for the system.
+NW_getFQDN.setFQDN = false
+
+# The load type chosen by the user. Valid values are: 'SAP', 'STD', 'OBR', 'HCP', 'MDA', 'HBR', 'SBR'
+NW_getLoadType.loadType = SAP
+
+# Password of the database manager operator user 'control' for liveCache
+# NW_liveCache.controlUserPwd =
+
+# Host name for liveCache
+# NW_liveCache.liveCacheHost =
+
+# Database ID for liveCache
+# NW_liveCache.liveCacheID =
+
+# Database schema for liveCache
+# NW_liveCache.liveCacheUser =
+
+# Password of database schema for liveCache
+# NW_liveCache.liveCacheUserPwd =
+
+# Specify whether you want to use liveCache. Default value is 'true'.
+# NW_liveCache.useLiveCache = false
+
+# The ASP device name where the SAP system will be in installed. The property is IBM i only.
+# Values from 1 to 256 can be specified. The default is 1, the System ASP.
+# OS4.DestinationASP =
+
+# The folder containing all archives that have been downloaded from http://support.sap.com/swdc and are supposed to be used in this procedure
+archives.downloadBasket = {{ sap_nw_kernel_files }}
+
+SAPINST.CD.PACKAGE.KERNEL = {{ sap_nw_kernel_files }}
+
+SAPINST.CD.PACKAGE.LOAD = {{ sap_product_vars[sap_nw_product_and_version].load_files }}
+
+SAPINST.CD.PACKAGE.RDBMS = {{ sap_nw_rdbms_files }}
+
+# Specify whether a Landscape Reorg Check Procedures file 'HdbLandscapeReorgCheckProcedure.SQL' is to be used. Possible values are 'USEFILE', 'DONOTUSEFILE','DONOTRUN'. Default value is 'USEFILE'.
+hanadb.landscape.reorg.useCheckProcedureFile = DONOTUSEFILE
+
+# Specify whether a Table Placement Parameters file 'HdbTablePlacementParameters.SQL' is to be used. Possible values are 'USEFILE', 'DONOTUSEFILE'. Default value is 'USEFILE'.
+hanadb.landscape.reorg.useParameterFile = DONOTUSEFILE
+
+# DBACOCKPIT user is to be created. Default value is 'true'.
+# hdb.create.dbacockpit.user = true
+
+# Windows only: The domain of the SAP Host Agent user
+# hostAgent.domain =
+
+# Password for the 'sapadm' user of the SAP Host Agent
+# hostAgent.sapAdmPassword =
+
+# installation_export.archivesFolder =
+
+# Windows only: The domain of all users of this SAP system. Leave empty for default.
+# nwUsers.sapDomain =
+
+# Windows only: The password of the 'SAPServiceSID' user
+# nwUsers.sapServiceSIDPassword =
+
+# UNIX only: The user ID of the 'sapadm' user, leave empty for default. The ID is ignored if the user already exists.
+# nwUsers.sapadmUID =
+
+# UNIX only: The group id of the 'sapsys' group, leave empty for default. The ID is ignored if the group already exists.
+# nwUsers.sapsysGID =
+
+# UNIX only: The user id of the <sapsid>adm user, leave empty for default. The ID is ignored if the user already exists.
+# nwUsers.sidAdmUID =
+
+# The password of the '<sapsid>adm' user
+nwUsers.sidadmPassword = {{ sap_nw_password }}
+
+# ABAP schema password
+# storageBasedCopy.abapSchemaPassword =
+
+# Sets the SAP<SAPSID>DB schema password using a  parameter file.
+# storageBasedCopy.javaSchemaPassword =

--- a/ansible/roles/sapinst/templates/inifile_onehost_java_hdb.params.j2
+++ b/ansible/roles/sapinst/templates/inifile_onehost_java_hdb.params.j2
@@ -1,0 +1,315 @@
+# {{ ansible_managed }}
+
+# Password for the Diagnostics Agent specific <dasid>adm user. Provided value may be encoded.
+# DiagnosticsAgent.dasidAdmPassword =
+
+# Windows domain in which the Diagnostics Agent users must be created. This is an optional property (Windows only).
+# DiagnosticsAgent.domain =
+
+# Windows only: Password for the Diagnostics Agent specific 'SAPService<DASID>' user.
+# DiagnosticsAgent.sapServiceDASIDPassword =
+
+# Specify whether Software Provisioning Manager is to drop the schema if it exists.
+# HDB_Schema_Check_Dialogs.dropSchema = false
+
+# The name of the database schema.
+HDB_Schema_Check_Dialogs.schemaName = SAPJAVA1
+
+# The password of the database schema.
+HDB_Schema_Check_Dialogs.schemaPassword = {{ sap_nw_password }}
+
+# Specify whether Software Provisioning Manager is to validate the schema name. The schema name must only contain numbers and capital letters. It  must not start with '_' . It cannot be 'SYS' or 'SYSTEM'.
+# HDB_Schema_Check_Dialogs.validateSchemaName = true
+
+# Use SAP HANA Media on CD, do not ask for SAR archives
+HDB_Software_Dialogs.useMediaCD = true
+
+# If set to 'true', an 'ms_acl_info' file is created. It manages the hosts from which the Message Server accepts connections.
+# MessageServer.configureAclInfo = false
+
+# Standard system only: Add gateway process to (A)SCS instance
+NW_CI_Instance.ascsInstallGateway = {{ sap_nw_ascs_install_gateway | lower }}
+
+# Standard system only: Add web dispatcher process to (A)SCS instance
+NW_CI_Instance.ascsInstallWebDispatcher = {{ sap_nw_ascs_install_web_dispatcher | lower }}
+
+# Standard system with AS ABAP only: ASCS instance number. Leave empty for default.
+# NW_CI_Instance.ascsInstanceNumber =
+
+# Standard system with AS ABAP only: Virtual host name for the ASCS instance. Leave empty for default.
+NW_CI_Instance.ascsVirtualHostname = {{ sap_nw_ascs_virtual_host }}
+
+# Instance number of the primary application server instance. Leave empty for default.
+NW_CI_Instance.ciInstanceNumber = {{ sap_nw_pas_instance_number }}
+
+# The ABAP message server port. Leave empty for default.
+# NW_CI_Instance.ciMSPort =
+
+# The internal ABAP message server port. Leave empty for default.
+# NW_CI_Instance.ciMSPortInternal =
+
+# Virtual host name of the primary application server instance . Leave empty for default.
+NW_CI_Instance.ciVirtualHostname = {{ sap_nw_pas_virtual_host }}
+
+# Create file 'prxyinfo(.DAT)' in the global directory, if it does not already exist and set 'gw/prxy_info' in the default profile accordingly.  Default is 'false'.
+# NW_CI_Instance.createGlobalProxyInfoFile = false
+
+# Create file 'reginfo(.DAT)' in the global directory. Default is 'false'.
+# NW_CI_Instance.createGlobalRegInfoFile = false
+
+# User-defined number of Java server nodes. Depends on NW_CI_Instance.nodesNumber.
+# NW_CI_Instance.nodesNum =
+
+# Number of Java server nodes. Possible values: 'defNodes' - default number; 'srcNodes' - copy from source; 'userNodes' - user-defined number. Default is 'defNodes'
+# NW_CI_Instance.nodesNumber = defNodes
+
+# Standard system with AS Java only: The SCS instance number. Leave empty for default.
+NW_CI_Instance.scsInstanceNumber = {{ sap_nw_ascs_instance_number }}
+
+# The internal Java message server port. Leave empty for default.
+# NW_CI_Instance.scsMSPortInternal =
+
+# Standard system with AS Java only: Virtual host name for the SCS instance. Leave empty for default.
+NW_CI_Instance.scsVirtualHostname = {{ sap_nw_ascs_virtual_host }}
+
+# System copy AS Java with product instance Process Integration and/or Development Infrastructure: Specify whether the target system should replace the source system. Possible values are  'true' or 'false'.
+# NW_CreateDBandLoad.movePVCforUsagePiAndDi =
+
+# Specify whether the all operating system users are to be removed from group 'sapinst' after the execution of Software Provisioning Manager has completed.
+# NW_Delete_Sapinst_Users.removeUsers = false
+
+# Master password
+NW_GetMasterPassword.masterPwd = {{ sap_nw_password }}
+
+# Human readable form of the default login language to be preselected in SAPGUI. This Parameter is potentialy prompted in addition in the screen that also asks for the <SAPSID>. It is only prompted in systems that have an ABAP stack. It is prompted for installation but not for system copy. It is asked in those installations, that perform the ABAP load. That could be the database load installation in case of a distributed system szenario, or in case of a standard system installation with all instances on one host. This Parameter is saved in the 'DEFAULT' profile. It is has no influence on language settings in a Java stack. Valid names are stored in a table of subcomponent 'NW_languagesInLoadChecks'. The available languages must be declaired in the 'LANGUAGES_IN_LOAD' parameter of the 'product.xml' file . In this file, the one-character representation of the languages is used. Check the same table in subcomponent 'NW_languagesInLoadChecks'.
+# NW_GetSidNoProfiles.SAP_GUI_DEFAULT_LANGUAGE =
+
+# Windows only: The drive to use
+# NW_GetSidNoProfiles.sapdrive =
+
+# Unix only: The SAP mount directory path. Default value is '/sapmnt'.
+# NW_GetSidNoProfiles.sapmnt = /sapmnt
+
+# The SAP system ID <SAPSID> of the system to be installed
+NW_GetSidNoProfiles.sid = {{ sap_nw_sid }}
+
+# Only use this parameter if recommended by SAP.
+# NW_GetSidNoProfiles.strictSidCheck = true
+
+# Specify whether this system is to be a Unicode system.
+# NW_GetSidNoProfiles.unicode = true
+
+# ABAP schema name
+# NW_HDB_DB.abapSchemaName =
+
+# Password of the ABAP schema user
+# NW_HDB_DB.abapSchemaPassword =
+
+# JAVA schema name
+NW_HDB_DB.javaSchemaName = SAPJAVA1
+
+# Password of the JAVA schema user
+NW_HDB_DB.javaSchemaPassword = {{ sap_nw_password }}
+
+# Skip checking if creating a HANA user store is needed. Default value is 'true'. If set to 'false', a valid HANA userstore must exists.
+# NW_HDB_DBClient.checkCreateUserstore = true
+
+# Install the SAP HANA database client in a central or local directory. Possible values are: 'SAPCPE', 'LOCAL'
+# NW_HDB_DBClient.clientPathStrategy = LOCAL
+
+# Data has already been loaded.
+# NW_HDB_getDBInfo.dataAlreadyLoaded = false
+
+# The DB admin user for SAP HANA tenant database. Default value: SYSTEM
+# NW_HDB_getDBInfo.dbadmin = SYSTEM
+
+# Database host
+NW_HDB_getDBInfo.dbhost = {{ sap_hana_virtual_host }}
+
+# Database system ID
+NW_HDB_getDBInfo.dbsid = {{ sap_hana_sid }}
+
+# The instance number of the SAP HANA database server
+NW_HDB_getDBInfo.instanceNumber = {{ sap_hana_instance_number }}
+
+# Password of user 'SYSTEM' within the 'SystemDB' tenant in an SAP HANA MultiDB server
+NW_HDB_getDBInfo.systemDbPassword = {{ sap_hana_db_system_password }}
+
+# Password of  SAP HANA administration database user.'
+NW_HDB_getDBInfo.systemPassword = {{ sap_hana_db_system_password }}
+
+# Password of user 'SYSTEM' inside the SAP HANA database server from a backup
+# NW_HDB_getDBInfo.systemPasswordBackup =
+
+# SAP HANA system ID
+NW_HDB_getDBInfo.systemid = {{ sap_hana_sid }}
+
+# A dedicated OS group for the tenant database, required for SAP HANA multitenant database containers with high isolation level.
+# NW_HDB_getDBInfo.tenantOsGroup =
+
+# A dedicated OS user for the tenant database, required for SAP HANA multitenant database containers with high isolation level.
+# NW_HDB_getDBInfo.tenantOsUser =
+
+# The SQL port for SAP HANA tenant database
+# NW_HDB_getDBInfo.tenantPort =
+
+# Connect using SSL/TLS. Default value: false.
+# NW_HDB_getDBInfo.usingSSL = false
+
+# Key phrase for the Java Secure Store in the file system. For system copy you must specify the key phrase of the source system. For the installation you can leave this value empty, then the master password is used.
+# NW_JAVA_Export.keyPhrase =
+
+# Possible values :
+#         true  : start the SAP MMC.
+#         false : no SAP MMC start.
+#         This parameter makes sense only on MS Windows, since SAP MMC is availible only there.
+# NW_Java_OneHost.startMMC = true
+
+# DEPRECATED, DO NOT USE!
+# NW_SAPCrypto.SAPCryptoFile =
+
+# Enable the instance agent (sapstartsrv) data supplier to send operating system information to the System Landscape Directory (SLD). Default is 'false'.
+# NW_SLD_Configuration.configureSld = false
+
+# Host of the System Landscape Directory (SLD)
+# NW_SLD_Configuration.sldHost =
+
+# Port used to connect to the System Landscape Directory (SLD)
+# NW_SLD_Configuration.sldPort =
+
+# Use HTTPS. Default is 'false'.
+# NW_SLD_Configuration.sldUseHttps = false
+
+# The user that is to authenticate towards the System Landscape Directory (SLD)
+# NW_SLD_Configuration.sldUser =
+
+# User password to authenticate towards the System Landscape Directory (SLD). Note: The connection is not checked by Software Provisioning Manager.
+# NW_SLD_Configuration.sldUserPassword =
+
+# SAP INTERNAL USE ONLY
+# NW_System.installSAPHostAgent = true
+
+# DEPRECATED, DO NOT USE!
+# NW_Unpack.dbaToolsSar =
+
+# DEPRECATED, DO NOT USE!
+# NW_Unpack.igsExeSar =
+
+# DEPRECATED, DO NOT USE!
+# NW_Unpack.igsHelperSar =
+
+# DEPRECATED, DO NOT USE!
+# NW_Unpack.sapExeDbSar =
+
+# DEPRECATED, DO NOT USE!
+# NW_Unpack.sapExeSar =
+
+# DEPRECATED, DO NOT USE!
+# NW_Unpack.sapJvmSar =
+
+# DEPRECATED, DO NOT USE!
+# NW_Unpack.xs2Sar =
+
+# SAP INTERNAL USE ONLY
+# NW_adaptProfile.templateFiles =
+
+# The FQDN of the system
+# NW_getFQDN.FQDN =
+
+# SAP INTERNAL USE ONLY
+# NW_getFQDN.resolve = true
+
+# Specify whether you want to set FQDN for the system.
+NW_getFQDN.setFQDN = false
+
+# The path to the jce policy archive to install it into the java home directory if it is not already installed.
+# NW_getJavaHome.jcePolicyArchive =
+
+# Manual configuration and execution of Migration Monitor or manual native database copy method.
+# NW_getLoadType.importManuallyExecuted = false
+
+# The load type chosen by the user. Valid values are: 'SAP', 'STD', 'OBR', 'HCP', 'FLASHCOPY', 'MDA', 'HBR', 'SBR'
+NW_getLoadType.loadType = SAP
+
+# SAP INTERNAL USE ONLY
+NW_internal.useProductVersionDescriptor = true
+
+# The ASP device name where the SAP system will be in installed. The property is IBM i only.
+# Values from 1 to 256 can be specified. The default is 1, the System ASP.
+# OS4.DestinationASP =
+
+# Controls whether build archives are copied to the system. This parameter is overwritten by the 'copyBuildarchives' switch in product.xml.
+Prepare_Deployment_Using_Product_Version_Descriptor.copyNWDIArchives = false
+
+# Comma-separated list of template IDs of product version instances to be installed. This can be used for unattended runs or for providing an initial selection using an inifile.xml or a parameter file. If an instance of the list is unknown with respect to the product version descriptor, the whole list is ignored.
+# Select_PPMS_Instances.ListOfSelectedInstances =
+
+# User Name of the AS Java  Administrator
+UmeConfiguration.adminName = Administrator
+
+# Password of the AS Java Administrator
+UmeConfiguration.adminPassword = {{ sap_nw_password }}
+
+# The guest user account is for anonymous access to the Java application server
+UmeConfiguration.guestName = Guest
+
+# User Name of the ABAP communication user
+# UmeConfiguration.sapjsfName = SAPJSF
+
+# Password of the ABAP communication user
+# UmeConfiguration.sapjsfPassword =
+
+# ABAP client, mandatory if 'UmeConfiguration.umeType' is 'abap'
+# UmeConfiguration.umeClient =
+
+# ABAP application host, mandatory if 'UmeConfiguration.umeType' is 'abap'
+# UmeConfiguration.umeHost =
+
+# ABAP application server instance number, mandatory if 'UmeConfiguration.umeType' is 'abap'
+# UmeConfiguration.umeInstance =
+
+# The User Management Engine (UME) type. Possible values are 'db' or 'abap'.
+# UmeConfiguration.umeType = db
+
+# The folder containing all archives that have been downloaded from http://support.sap.com/swdc and are supposed to be used in this procedure
+archives.downloadBasket = {{ sap_nw_kernel_files }}
+
+SAPINST.CD.PACKAGE.LOAD = {{ sap_product_vars[sap_nw_product_and_version].load_files }}
+
+SAPINST.CD.PACKAGE.RDBMS = {{ sap_nw_rdbms_files }}
+
+# DBACOCKPIT user is to be created. Default value is 'true'.
+# hdb.create.dbacockpit.user = true
+
+# Windows only: The domain of the SAP Host Agent user
+# hostAgent.domain =
+
+# Password for the 'sapadm' user of the SAP Host Agent
+# hostAgent.sapAdmPassword =
+
+# Windows only: The domain of all users of this SAP system. Leave empty for default.
+# nwUsers.sapDomain =
+
+# Windows only: The password of the 'SAPServiceSID' user
+# nwUsers.sapServiceSIDPassword =
+
+# UNIX only: The user ID of the 'sapadm' user, leave empty for default. The ID is ignored if the user already exists.
+# nwUsers.sapadmUID =
+
+# UNIX only: The group id of the 'sapsys' group, leave empty for default. The ID is ignored if the group already exists.
+# nwUsers.sapsysGID =
+
+# UNIX only: The user id of the <sapsid>adm user, leave empty for default. The ID is ignored if the user already exists.
+# nwUsers.sidAdmUID =
+
+# The password of the '<sapsid>adm' user
+nwUsers.sidadmPassword = {{ sap_nw_password }}
+
+# SAP INTERNAL USE ONLY
+# nw_java_import.buildJEEusingExtraMileTool = false
+
+# ABAP schema password
+# storageBasedCopy.abapSchemaPassword =
+
+# Sets the SAP<SAPSID>DB schema password using a  parameter file.
+# storageBasedCopy.javaSchemaPassword =


### PR DESCRIPTION
The sapinst role is a generic role for running SWPM. This is phase one of
converting everything to use it instead of roles such as nw, ascs, ers, and
others which also run SWPM.