### PR TITLE
Add option to install Gateway and WebDispatcher for DB2

### DIFF
--- a/ansible/roles/nw-db2-distributed/defaults/main.yml
+++ b/ansible/roles/nw-db2-distributed/defaults/main.yml
@@ -79,6 +79,9 @@ sap_nw_install_files_dest: /sapmnt/Software
 sap_nw_kernel_files: /sapmnt/Software/Kernel_Files
 sap_nw_rdbms_files: /sapmnt/Software/RDBMS
 
+sap_nw_ascs_install_gateway: false
+sap_nw_ascs_install_web_dispatcher: false
+
 sap_nw_sapmnt_nfs_mount_src: '{{ sap_nw_ascs_private_ip }}:/sapmnt'
 sap_nw_saptrans_nfs_mount_src: '{{ sap_nw_ascs_private_ip }}:/usr/sap/trans'
 

--- a/ansible/roles/nw-db2-distributed/tasks/assertions.yml
+++ b/ansible/roles/nw-db2-distributed/tasks/assertions.yml
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: define optional processes
+  set_fact:
+    sap_nw_gw_proc: '{{ "GATEWAY|" if sap_nw_ascs_install_gateway | bool else "" }}'
+    sap_nw_wd_proc: '{{ "|WEBDISP" if sap_nw_ascs_install_web_dispatcher | bool else "" }}'
+
 - name: include sap assertions role for ascs
   include_role:
     name: sap-assertions
@@ -21,7 +26,7 @@
     - msg_server, MessageServer, GREEN, Running
     - '{{ "enserver, EnqueueServer, GREEN, Running" if sap_product_vars[sap_nw_product_and_version].ensa_version == "1" else "enq_server, Enqueue Server 2, GREEN, Running" }}'
     sap_instances:
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, {{ sap_nw_gw_proc }}MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_pas_virtual_host }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, ABAP|GATEWAY|ICMAN|IGS, GREEN'
     sap_instance_number: '{{ sap_nw_ascs_instance_number }}'
   when: sap_is_ascs | bool
@@ -37,7 +42,7 @@
     - gwrd, Gateway, GREEN, Running
     - icman, ICM, GREEN, Running
     sap_instances:
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, {{ sap_nw_gw_proc }}MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_pas_virtual_host }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, ABAP|GATEWAY|ICMAN|IGS, GREEN'
     sap_instance_number: '{{ sap_nw_pas_instance_number }}'
   when: sap_is_pas | bool

--- a/ansible/roles/nw-db2-ha/defaults/main.yml
+++ b/ansible/roles/nw-db2-ha/defaults/main.yml
@@ -63,6 +63,9 @@ sap_nw_install_files_dest: /sapmnt/Software
 sap_nw_kernel_files: /sapmnt/Software/Kernel_Files
 sap_nw_rdbms_files: /sapmnt/Software/RDBMS
 
+sap_nw_ascs_install_gateway: false
+sap_nw_ascs_install_web_dispatcher: false
+
 # Defaults for using Cloud Filestore. Only sap_nw_nfs_server needs to be defined
 # in variables if it is used.
 sap_nw_nfs_server: ''

--- a/ansible/roles/nw-db2-ha/tasks/assertions.yml
+++ b/ansible/roles/nw-db2-ha/tasks/assertions.yml
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: define optional processes
+  set_fact:
+    sap_nw_gw_proc: '{{ "GATEWAY|" if sap_nw_ascs_install_gateway | bool else "" }}'
+    sap_nw_wd_proc: '{{ "|WEBDISP" if sap_nw_ascs_install_web_dispatcher | bool else "" }}'
+
 - name: define pacemaker expected status for redhat
   set_fact:
     # sap-assertions role requires sap_expected_pacemaker_status variable
@@ -62,8 +67,8 @@
     - '{{ "enserver, EnqueueServer, GREEN, Running" if sap_product_vars[sap_nw_product_and_version].ensa_version == "1" else "enq_server, Enqueue Server 2, GREEN, Running" }}'
     sap_instances:
     - '{{ sap_nw_pas_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, ABAP|GATEWAY|ICMAN|IGS, GREEN'
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GRAY'
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, {{ sap_nw_gw_proc }}MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GRAY'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, {{ sap_nw_gw_proc }}MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_ers_virtual_host }}, {{ sap_nw_ers_instance_number | int }}, 5{{ sap_nw_ers_instance_number }}13, 5{{ sap_nw_ers_instance_number }}14, 0.5, ENQREP, GRAY'
     - '{{ sap_nw_ers_virtual_host }}, {{ sap_nw_ers_instance_number | int }}, 5{{ sap_nw_ers_instance_number }}13, 5{{ sap_nw_ers_instance_number }}14, 0.5, ENQREP, GREEN'
     sap_instance_number: '{{ sap_nw_ascs_instance_number }}'
@@ -79,8 +84,8 @@
     - '{{ "enrepserver, EnqueueReplicator, GREEN, Running" if sap_product_vars[sap_nw_product_and_version].ensa_version == "1" else "enq_replicator, Enqueue Replicator 2, GREEN, Running" }}'
     sap_instances:
     - '{{ sap_nw_pas_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, ABAP|GATEWAY|ICMAN|IGS, GREEN'
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GRAY'
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, {{ sap_nw_gw_proc }}MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GRAY'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, {{ sap_nw_gw_proc }}MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_ers_virtual_host }}, {{ sap_nw_ers_instance_number | int }}, 5{{ sap_nw_ers_instance_number }}13, 5{{ sap_nw_ers_instance_number }}14, 0.5, ENQREP, GRAY'
     - '{{ sap_nw_ers_virtual_host }}, {{ sap_nw_ers_instance_number | int }}, 5{{ sap_nw_ers_instance_number }}13, 5{{ sap_nw_ers_instance_number }}14, 0.5, ENQREP, GREEN'
     sap_instance_number: '{{ sap_nw_ers_instance_number }}'
@@ -100,8 +105,8 @@
     - icman, ICM, GREEN, Running
     sap_instances:
     - '{{ sap_nw_pas_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, ABAP|GATEWAY|ICMAN|IGS, GREEN'
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GRAY'
-    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, {{ sap_nw_gw_proc }}MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GRAY'
+    - '{{ sap_nw_ascs_virtual_host }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, {{ sap_nw_gw_proc }}MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_ers_virtual_host }}, {{ sap_nw_ers_instance_number | int }}, 5{{ sap_nw_ers_instance_number }}13, 5{{ sap_nw_ers_instance_number }}14, 0.5, ENQREP, GRAY'
     - '{{ sap_nw_ers_virtual_host }}, {{ sap_nw_ers_instance_number | int }}, 5{{ sap_nw_ers_instance_number }}13, 5{{ sap_nw_ers_instance_number }}14, 0.5, ENQREP, GREEN'
     sap_instance_number: '{{ sap_nw_pas_instance_number }}'

--- a/ansible/roles/nw-db2-standard/defaults/main.yml
+++ b/ansible/roles/nw-db2-standard/defaults/main.yml
@@ -38,6 +38,9 @@ sap_nw_install_files_dest: /sapmnt/Software
 sap_nw_kernel_files: /sapmnt/Software/Kernel_Files
 sap_nw_rdbms_files: /sapmnt/Software/RDBMS
 
+sap_nw_ascs_install_gateway: false
+sap_nw_ascs_install_web_dispatcher: false
+
 sap_db2_product: 'DB2'
 sap_db2_product_version: '11.5MP5FP1'
 sap_db2_product_and_version: '{{ sap_db2_product }}/{{ sap_db2_product_version }}'

--- a/ansible/roles/nw-db2-standard/tasks/assertions.yml
+++ b/ansible/roles/nw-db2-standard/tasks/assertions.yml
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: define optional processes
+  set_fact:
+    sap_nw_gw_proc: '{{ "GATEWAY|" if sap_nw_ascs_install_gateway | bool else "" }}'
+    sap_nw_wd_proc: '{{ "|WEBDISP" if sap_nw_ascs_install_web_dispatcher | bool else "" }}'
+
 - name: include sap assertions role for ascs
   include_role:
     name: sap-assertions
@@ -21,7 +26,7 @@
     - msg_server, MessageServer, GREEN, Running
     - '{{ "enserver, EnqueueServer, GREEN, Running" if sap_product_vars[sap_nw_product_and_version].ensa_version == "1" else "enq_server, Enqueue Server 2, GREEN, Running" }}'
     sap_instances:
-    - '{{ sap_nw_instance_name }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_instance_name }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, {{ sap_nw_gw_proc }}MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, ABAP|GATEWAY|ICMAN|IGS, GREEN'
     sap_instance_number: '{{ sap_nw_ascs_instance_number }}'
 
@@ -36,6 +41,6 @@
     - gwrd, Gateway, GREEN, Running
     - icman, ICM, GREEN, Running
     sap_instances:
-    - '{{ sap_nw_instance_name }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, MESSAGESERVER|ENQUE, GREEN'
+    - '{{ sap_nw_instance_name }}, {{ sap_nw_ascs_instance_number | int }}, 5{{ sap_nw_ascs_instance_number }}13, 5{{ sap_nw_ascs_instance_number }}14, 1, {{ sap_nw_gw_proc }}MESSAGESERVER|ENQUE{{ sap_nw_wd_proc }}, GREEN'
     - '{{ sap_nw_instance_name }}, {{ sap_nw_pas_instance_number | int }}, 5{{ sap_nw_pas_instance_number }}13, 5{{ sap_nw_pas_instance_number }}14, 3, ABAP|GATEWAY|ICMAN|IGS, GREEN'
     sap_instance_number: '{{ sap_nw_pas_instance_number }}'

--- a/ansible/roles/sapinst/templates/inifile_ascs.params.j2
+++ b/ansible/roles/sapinst/templates/inifile_ascs.params.j2
@@ -34,11 +34,26 @@ NW_GetSidNoProfiles.unicode = true
 # DEPRECATED, DO NOT USE!
 # NW_SAPCrypto.SAPCryptoFile =
 
-# Add gateway process in the (A)SCS instance
-# NW_SCS_Instance.ascsInstallGateway = false
+# Add gateway process in the ASCS instance
+NW_SCS_Instance.ascsInstallGateway = {{ sap_nw_ascs_install_gateway | lower }}
 
-# Add Web Dispatcher process in the (A)SCS instance
-# NW_SCS_Instance.ascsInstallWebDispatcher = false
+# Add Web Dispatcher process in the ASCS instance
+NW_SCS_Instance.ascsInstallWebDispatcher = {{ sap_nw_ascs_install_web_dispatcher | lower }}
+
+# There are three types of encryption modes: 'Always' (default), 'depending on the incoming protocol', 'Never'
+NW_webdispatcher_Instance.encryptionMode = {{ sap_nw_wd_encryption_mode | default('Always') }}
+
+# Operating systems have restrictions for maximum number of open 'file handles' (sockets) for each process. Default is 2048. Provide a much higher value for  scenarios with heavy workload.
+NW_webdispatcher_Instance.scenarioSize = {{ sap_nw_wd_scenario_size | default('2048') }}
+
+# Set this parameter to 'true' if the SAP Web Dispatcher HTTP Port is to be used.
+NW_webdispatcher_Instance.useWdHTTPPort = {{ sap_nw_wd_use_http | default('true') | lower }}
+
+# HTTP Port of SAP Web Dispatcher. You can only specify this parameter if 'NW_webdispatcher_Instance.useWdHTTPPort' is set to 'true'.
+NW_webdispatcher_Instance.wdHTTPPort = {{ sap_nw_wd_http_port | default('8000') }}
+
+# HTTPS Port of SAP Web Dispatcher.
+NW_webdispatcher_Instance.wdHTTPSPort = {{ sap_nw_wd_https_port | default('44300') }}
 
 # Dual stack only: Specify the ASCS instance number. Leave empty for default.
 NW_SCS_Instance.ascsInstanceNumber = {{ sap_nw_ascs_instance_number }}

--- a/ansible/roles/sapinst/templates/inifile_onehost_db2.params.j2
+++ b/ansible/roles/sapinst/templates/inifile_onehost_db2.params.j2
@@ -47,10 +47,25 @@ NW_ABAP_Import_Dialog.migmonLoadArgs = -stop_on_error -loadprocedure fast LOAD:C
 # NW_ABAP_SSFS_CustomKey.ssfsKeyInputFile =
 
 # Standard system only: Add gateway process to (A)SCS instance
-# NW_CI_Instance.ascsInstallGateway = false
+NW_CI_Instance.ascsInstallGateway = {{ sap_nw_ascs_install_gateway | lower }}
 
 # Standard system only: Add web dispatcher process to (A)SCS instance
-# NW_CI_Instance.ascsInstallWebDispatcher = false
+NW_CI_Instance.ascsInstallWebDispatcher = {{ sap_nw_ascs_install_web_dispatcher | lower }}
+
+# There are three types of encryption modes: 'Always' (default), 'depending on the incoming protocol', 'Never'
+NW_webdispatcher_Instance.encryptionMode = {{ sap_nw_wd_encryption_mode | default('Always') }}
+
+# Operating systems have restrictions for maximum number of open 'file handles' (sockets) for each process. Default is 2048. Provide a much higher value for  scenarios with heavy workload.
+NW_webdispatcher_Instance.scenarioSize = {{ sap_nw_wd_scenario_size | default('2048') }}
+
+# Set this parameter to 'true' if the SAP Web Dispatcher HTTP Port is to be used.
+NW_webdispatcher_Instance.useWdHTTPPort = {{ sap_nw_wd_use_http | default('true') | lower }}
+
+# HTTP Port of SAP Web Dispatcher. You can only specify this parameter if 'NW_webdispatcher_Instance.useWdHTTPPort' is set to 'true'.
+NW_webdispatcher_Instance.wdHTTPPort = {{ sap_nw_wd_http_port | default('8000') }}
+
+# HTTPS Port of SAP Web Dispatcher.
+NW_webdispatcher_Instance.wdHTTPSPort = {{ sap_nw_wd_https_port | default('44300') }}
 
 # Standard system with AS ABAP only: ASCS instance number. Leave empty for default.
 NW_CI_Instance.ascsInstanceNumber = {{ sap_nw_ascs_instance_number }}


### PR DESCRIPTION
Running Gateway and WebDispatcher on ASCS is already supported on systems
with HANA, and this adds it for DB2 as well. This will enable HANA and DB2
systems to share `inifile_ascs.params` when HANA starts using the sapinst role.