### PR TITLE
Wait for guest registration before installing packages

### DIFF
--- a/ansible/roles/base/defaults/main.yml
+++ b/ansible/roles/base/defaults/main.yml
@@ -15,3 +15,4 @@
 package_retries_cnt: 50
 package_retries_delay: 10
 cloudsdk_url: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-340.0.0-linux-x86_64.tar.gz
+wait_for_guest_register: true

--- a/ansible/roles/base/tasks/os.yml
+++ b/ansible/roles/base/tasks/os.yml
@@ -12,6 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Wait for guest registration
+  command: systemctl is-active guestregister.service
+  register: guestregister
+  retries: 30
+  delay: 20
+  until: guestregister.stdout == 'inactive'
+  failed_when: guestregister.rc != 3
+  changed_when: false
+  when:
+  - ansible_os_family == 'Suse'
+  - wait_for_guest_register | bool
+
 - name: Install packages
   package:
     name: "{{ package_list }}"


### PR DESCRIPTION
On Suse, package installation can fail if zypper runs before guest registration
has completed. This waits for the guestregister service to finish before running
zypper.