### PR TITLE
sap_sapinst_template use template basename

### DIFF
--- a/ansible/roles/sapinst/tasks/main.yml
+++ b/ansible/roles/sapinst/tasks/main.yml
@@ -22,7 +22,7 @@
 - name: expand inifile.params
   template:
     src: '{{ sap_sapinst_template }}.j2'
-    dest: /usr/sap/{{ sap_sapinst_template }}
+    dest: /usr/sap/{{ sap_sapinst_template | basename }}
     mode: '0600'
     owner: root
     group: root


### PR DESCRIPTION
make sapinst role template dest use sap_sapinst_template | basename to allow for fully qualified src template paths 