### PR TITLE
Add linting capability

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,78 @@
+---
+# .ansible-lint
+# exclude_paths included in this file are parsed relative to this file's location
+# and not relative to the CWD of execution. CLI arguments passed to the --exclude
+# option will be parsed relative to the CWD of execution.
+exclude_paths:
+  - .cache/ # implicit unless exclude_paths is defined in config
+  - .github/
+  - docs/
+  - images/
+  - third_party/
+  - terraform/
+  - build/
+  #- stacks/HANA-Scaleout-Standby/playbook-notf.yml
+  #- stacks/netweaver-aas-ha/playbook.yml
+  #- stacks/nw-ad-app/playbook.yml
+# parseable: true
+# quiet: true
+# verbosity: 1
+
+use_default_rules: true
+# Load custom rules from this specific folder
+# rulesdir:
+#   - ./rule/directory/
+
+# This makes linter to fully ignore rules/tags listed below
+skip_list:
+  - skip_this_tag
+  - git-latest
+  - fqcn-builtins
+  - meta-no-info
+
+# Any rule that has the 'opt-in' tag will not be loaded unless its 'id' is
+# mentioned in the enable_list:
+#enable_list:
+#  - empty-string-compare # opt-in
+#  - no-log-password # opt-in
+#  - no-same-owner # opt-in
+  # add yaml here if you want to avoid ignoring yaml checks when yamllint
+  # library is missing. Normally its absence just skips using that rule.
+#  - yaml
+# Report only a subset of tags and fully ignore any others
+# tags:
+#   - var-spacing
+
+# This makes the linter display but not fail for rules/tags listed below:
+warn_list:
+  - experimental # experimental is included in the implicit list
+  - command-instead-of-module  # Using command rather than module.
+  - experimental  # all rules tagged as experimental
+  - literal-compare  # Don't compare to literal True/False.
+  - no-changed-when  # Commands should not change things if nothing needs doing.
+  - no-handler  # Tasks that run when changed should likely be handlers.
+  - no-tabs  # Most files should not contain tabs.
+  - package-latest  # Package installs should not use latest.
+  - risky-shell-pipe  # Shells that use pipes should set the pipefail option.
+  - role-name  # Role name {0} does not match ``^[a-z][a-z0-9_]+$`` pattern.
+  - unnamed-task  # All tasks should be named.
+  - var-spacing  # Variables should have spaces before and after: {{ var_name }}.
+  - yaml  # Violations reported by yamllint.
+
+# Offline mode disables installation of requirements.yml
+offline: true
+
+
+# Uncomment to enforce action validation with tasks, usually is not
+# needed as Ansible syntax check also covers it.
+# skip_action_validation: false
+
+# List of additional kind:pattern to be added at the top of the default
+# match list, first match determines the file kind.
+kinds:
+  # - playbook: "**/examples/*.{yml,yaml}"
+  # - galaxy: "**/folder/galaxy.yml"
+  # - tasks: "**/tasks/*.yml"
+  # - vars: "**/vars/*.yml"
+  # - meta: "**/meta/main.yml"
+  - yaml: "**/*.yaml-too"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ ssh-key
 ssh-key.pub
 terraform.tfstate
 terraform.tfstate.backup
+.terraform.lock.hcl
 .cache/
 .terraform/
+test/integration/tmp
 venv/
+.idea/
+credentials.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,3 +27,38 @@ All submissions, including submissions by project members, require review. We
 use GitHub pull requests for this purpose. Consult
 [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
 information on using pull requests.
+
+## Testing
+Testing can be done through `sap-gcp-developer-tools` container. To build this
+container run `make docker_build`.<br>
+The `sap-gcp-developer-tools` container comes with the following tools:
+following tools:
+- ansible-core
+- ansible-lint
+- galaxy
+- terraform
+- gcloud
+- shellcheck
+
+More details can be found in [Dockerfile](build/Dockerfile)
+
+### Interactive Execution
+Run `make docker_run` to start the testing Docker container in interactive mode.
+
+### Linting and Formatting
+Many of the files in the repository can be linted or formatted to
+maintain a standard of quality.
+
+Run `make docker_test_lint`.
+Linting will verify:
+- ansible files using `ansible-lint`
+- terraform files using `terraform fmt` and `terraform validate`
+- shell files using `shellcheck`
+- python files using `flake8`
+- License header
+
+#### Running lint on local cloud-build
+You can also test the cloud-build configuration locally by running:<br>
+`make cbl_lint`
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Please note that this file was generated from [terraform-google-module-template](https://github.com/terraform-google-modules/terraform-google-module-template).
+# Please make sure to contribute relevant changes upstream!
+
+# Make will use bash instead of sh
+SHELL := /usr/bin/env bash
+
+DOCKER_IMAGE_DEVELOPER_TOOLS := sap-gcp-developer-tools
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.1
+DOCKER_BIN ?= docker
+
+# Build docker container for local development
+.PHONY: docker_build
+docker_build:
+	$(DOCKER_BIN) build -t ${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} build/
+
+# Enter docker container for local development
+.PHONY: docker_run
+docker_run:
+	$(DOCKER_BIN) run --rm -it \
+		-v "$(CURDIR)":/workspace \
+		${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
+		/bin/bash
+
+# Run lint
+.PHONY: docker_lint
+docker_lint:
+	$(DOCKER_BIN) run --rm -it \
+		-v "$(CURDIR)":/workspace \
+		${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
+		/usr/local/bin/test_lint.sh
+
+# Run cloud build locally. This is meant only for local testing of the cloud-build configuration
+.PHONY: cbl_lint
+cbl_lint:
+	cloud-build-local --config=build/lint.cloudbuild.yaml --dryrun=false  .

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,39 @@
+FROM python:3.9-slim
+ENV TF_VERSION=1.1.7
+ENV CLOUD_SDK_VERSION=378.0.0
+ENV PATH /usr/local/google-cloud-sdk/bin:$PATH
+ENV WORKSPACE /workspace
+ENV TF_PLUGIN_CACHE_DIR /${WORKSPACE}/test/integration/tmp/.terraform
+
+RUN mkdir -p ${WORKSPACE}
+RUN apt-get update
+RUN apt-get install git curl gnupg zip unzip shellcheck -y
+
+# Setup terraform
+RUN curl https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip --output /tmp/terraform_${TF_VERSION}_linux_amd64.zip
+RUN unzip  /tmp/terraform_${TF_VERSION}_linux_amd64.zip -d /tmp
+RUN cp /tmp/terraform /usr/local/bin/terraform
+RUN chmod a+x /usr/local/bin/terraform
+# Set TF cache dir
+RUN mkdir -p ${TF_PLUGIN_CACHE_DIR}
+
+# Setup gcloud
+RUN mkdir -p build
+COPY ./scripts/install_cloud_sdk.sh /build/
+RUN chmod a+x  /build/install_cloud_sdk.sh
+RUN /build/install_cloud_sdk.sh ${CLOUD_SDK_VERSION}
+
+# Setup ansible
+RUN pip install ansible-lint flake8
+RUN ansible-galaxy collection install community.general
+RUN ansible-galaxy collection install google.cloud
+
+COPY scripts/task_helper_functions.sh /usr/local/bin/task_helper_functions.sh
+COPY scripts/terraform_validate /usr/local/bin/terraform_validate
+COPY scripts/.bashrc /root/.bashrc
+COPY scripts/test_lint.sh /usr/local/bin/test_lint.sh
+RUN chmod a+x /usr/local/bin/terraform_validate
+RUN chmod a+x /usr/local/bin/test_lint.sh
+
+WORKDIR ${WORKSPACE}
+CMD ["/bin/bash"]

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -1,0 +1,18 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+steps:
+- name: "sap-gcp-developer-tools:0.1"
+  id: "0"
+  args:
+    - /usr/local/bin/test_lint.sh

--- a/build/scripts/.bashrc
+++ b/build/scripts/.bashrc
@@ -1,0 +1,11 @@
+PS1='[\u@\h \W]\$ '
+
+if [[ -z "${CFT_DISABLE_INIT_CREDENTIALS:-}" ]]; then
+  echo 'Loading /usr/local/bin/task_helper_functions.sh from ~/.bashrc' >&2
+  # shellcheck disable=1091
+  source /usr/local/bin/task_helper_functions.sh
+  #echo 'Invoking init_credentials from ~/.bashrc' >&2
+  #echo 'Disable this behavior by setting CFT_DISABLE_INIT_CREDENTIALS=yes' >&2
+  init_tf_plugin_cache
+  #init_credentials
+fi

--- a/build/scripts/install_cloud_sdk.sh
+++ b/build/scripts/install_cloud_sdk.sh
@@ -1,0 +1,38 @@
+#! /bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+
+CLOUD_SDK_VERSION=$1
+
+cd /build
+
+curl --output google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz"
+tar -C /usr/local -xzf "google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz"
+rm "google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz"
+
+# TODO: Cargo-culted the symlink from a previous method. Would be nice to know
+# why this is necessary
+ln -s /lib /lib64
+
+gcloud config set core/disable_usage_reporting true
+gcloud config set component_manager/disable_update_check true
+gcloud config set survey/disable_prompts true
+gcloud components install beta --quiet
+gcloud components install alpha --quiet
+
+gcloud --version
+gsutil version -l

--- a/build/scripts/task_helper_functions.sh
+++ b/build/scripts/task_helper_functions.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# find_files is a helper to exclude .git directories and match only regular
+# files to avoid double-processing symlinks.
+# You can ignore directories by setting two different environment variables of
+#   relative escaped paths separated by a pipe
+# (1) EXCLUDE_LINT_DIRS - all files pointed to by this variable are skipped
+#                         during ANY USE of the find_files function
+#     E.g.: EXCLUDE_LINT_DIRS="\./scripts/foo|\./scripts/bar"
+# (2) EXCLUDE_HEADER_CHECK - all files pointed to by this variable are skipped
+#                            ONLY WHEN the "for_header_check" flag is passed in
+#     E.g.: EXCLUDE_HEADER_CHECK="\./config/foo_resource.yml|\./scripts/bar_script.sh"
+find_files() {
+  local pth="$1" find_path_regex="(" exclude_dirs=( ".*/\.git"
+    ".*/\.terraform"
+    ".*/\.kitchen"
+    ".*/.*\.png"
+    ".*/.*\.jpg"
+    ".*/.*\.jpeg"
+    ".*/.*\.svg"
+    "\./venv"
+    "\./autogen"
+    "\./third_party"
+    "\./test/fixtures/all_examples"
+    "\./test/fixtures/shared"
+    "\./cache"
+    "\./test/source\.sh" )
+  shift
+
+  # Concat all of the above dirs except the last, separated by a pipe
+  for ((index=0; index<$((${#exclude_dirs[@]}-1)); ++index)); do
+    find_path_regex+="${exclude_dirs[index]}|"
+  done
+
+  # Add any regex supplied to ignore other dirs
+  if [[ -n "${EXCLUDE_LINT_DIRS-}" ]]; then
+    find_path_regex+="${EXCLUDE_LINT_DIRS}"
+    find_path_regex+="|"
+  fi
+
+  # if find_files is used for validating license headers
+  if [ $1 = "for_header_check" ]; then
+    # Add any files to be skipped for header check
+    if [[ -n "${EXCLUDE_HEADER_CHECK-}" ]]; then
+      find_path_regex+="${EXCLUDE_HEADER_CHECK}"
+      find_path_regex+="|"
+    fi
+    shift
+  fi
+
+  # Concat last dir, along with closing paren
+  find_path_regex+="${exclude_dirs[-1]})"
+  # find_path_regex should be a string of this format:
+  # (some_relative_path|another_relative_path)
+  # ex: find_path_regex = (.*/\.git|.*/\.terraform|.*/\.kitchen|.*/.*\.png)
+
+  # Note: Take care to use -print or -print0 when using this function,
+  # otherwise excluded directories will be included in the output.
+  find "${pth}" -regextype posix-egrep -regex "${find_path_regex}" \
+    -prune -o -type f "$@"
+}
+
+# Compatibility with both GNU and BSD style xargs.
+compat_xargs() {
+  local compat=()
+  # Test if xargs is GNU or BSD style.  GNU xargs will succeed with status 0
+  # when given --no-run-if-empty and no input on STDIN.  BSD xargs will fail and
+  # exit status non-zero If xargs fails, assume it is BSD style and proceed.
+  # stderr is silently redirected to avoid console log spam.
+  if xargs --no-run-if-empty </dev/null 2>/dev/null; then
+    compat=("--no-run-if-empty")
+  fi
+  xargs "${compat[@]}" "$@"
+}
+
+# This function creates TF_PLUGIN_CACHE_DIR if TF_PLUGIN_CACHE_DIR envvar is set
+function init_tf_plugin_cache() {
+  if [[ ! -z "${TF_PLUGIN_CACHE_DIR}" ]]; then
+    mkdir -p ${TF_PLUGIN_CACHE_DIR}
+  fi
+}
+
+# This function runs 'terraform validate' against all
+# directory paths which contain *.tf files.
+function check_terraform() {
+  set -e
+  local rval rc
+  rval=0
+
+  init_tf_plugin_cache
+
+  # fmt is before validate for faster feedback, validate requires terraform
+  # init which takes time.
+  echo "Running terraform fmt"
+  while read -r file; do
+    terraform fmt -diff -check=true -write=false "$file"
+    rc="$?"
+    if [[ "${rc}" -ne 0 ]]; then
+      echo "Error: terraform fmt failed with exit code ${rc}" >&2
+      echo "Check the output for diffs and correct using terraform fmt <dir>" >&2
+      rval="$rc"
+    fi
+  done <<< "$(find_files . -name "*.tf" -print)"
+  if [[ "${rval}" -ne 0 ]]; then
+    return "${rval}"
+  fi
+  echo "Running terraform validate"
+  # Change to a temporary directory to avoid re-initializing terraform init
+  # over and over in the root of the repository.
+
+  # If enable parallel, run validate in parallel
+  if [[ "${ENABLE_PARALLEL:-}" -eq 1 ]]; then
+    find_files . -name "*.tf" -print \
+    | grep -v 'test/fixtures/shared' \
+    | compat_xargs -n1 dirname \
+    | sort -u \
+    | parallel --keep-order --retries 3 --joblog /tmp/lint_log terraform_validate
+    cat /tmp/lint_log
+  else
+    find_files . -name "*.tf" -print \
+    | grep -v 'test/fixtures/shared' \
+    | compat_xargs -n1 dirname \
+    | sort -u \
+    | compat_xargs -t -n1 terraform_validate
+  fi
+}
+
+# Check for common whitespace errors:
+# Trailing whitespace at the end of line
+# Missing newline at end of file
+check_whitespace() {
+  local rc
+  echo "Checking for trailing whitespace"
+  find_files . -print \
+    | grep -v -E '\.(pyc|png|gz|tfvars)$' \
+    | compat_xargs grep -H -n '[[:blank:]]$'
+  rc=$?
+  if [[ ${rc} -eq 0 ]]; then
+    printf "Error: Trailing whitespace found in the lines above.\n\n"
+    ((rc++))
+  else
+    rc=0
+  fi
+  echo "Checking for missing newline at end of file"
+  find_files . -print \
+    | grep -v -E '\.(png|gz|tfvars)$' \
+    | compat_xargs check_eof_newline
+  return $((rc+$?))
+}
+
+# This function runs the shellcheck linter on every
+# file ending in '.sh'
+function check_shell() {
+  echo "Running shellcheck"
+  find_files . -name "*.sh" -print0 | compat_xargs -0 shellcheck -x
+}
+
+# This function runs the flake8 linter on every file
+# ending in '.py'
+function check_python() {
+  echo "Running flake8"
+  find_files . -name "*.py" -print0 | compat_xargs -0 flake8
+}
+
+function check_headers() {
+  echo "Checking file headers"
+  # Use the exclusion behavior of find_files(); a second argument
+  # "for_header_check" is passed in, to ensure filtering based on the evironment
+  # variable EXCLUDE_HEADER_CHECK is done only when find_files is called here
+  find_files . for_header_check -type f -print0 | compat_xargs -0 addlicense -check 2>&1
+}
+
+function check_ansible() {
+  echo "Running ansible-lint"
+  ansible-lint
+}

--- a/build/scripts/terraform_validate
+++ b/build/scripts/terraform_validate
@@ -1,0 +1,16 @@
+#! /bin/bash
+#
+# Copyright 2019 Google LLC. This software is provided as-is, without warranty
+# or representation for any use or purpose. Your use of it is subject to your
+# agreement with Google.
+#
+
+# The first and only argument to this script is the directory containing *.tf
+# files to validate.  This directory is assumed to be a root module.
+
+set -eu
+curdir=$(pwd)
+cd "${1}"
+terraform init -backend=false >/dev/null
+terraform validate
+cd "$curdir"

--- a/build/scripts/test_lint.sh
+++ b/build/scripts/test_lint.sh
@@ -1,0 +1,103 @@
+#! /bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+# Import helper functions from Docker container
+# shellcheck disable=SC1091
+source /usr/local/bin/task_helper_functions.sh
+
+# All tests should execute regardless of failures so we can report at the end.
+# Perform 'set +e' after sourcing task_helper_functions.sh in case someone has
+# 'set -e' inside a module-specific task_helper_functions.sh file.
+set +e
+
+# constants
+MARKDOWN=0
+MARKDOWN_STR=""
+CONTRIBUTING_GUIDE=""
+# shellcheck disable=SC2089,SC2016  # Quotes/backslashes will be treated literally, expressions don't expand
+messages='{
+  "check_headers": "All files need a license header. Please make sure all your files include the appropriate header. A helper tool available [here](https://github.com/google/addlicense).",
+  "check_shell": "Failed shell check. More info on running shellcheck locally [here](https://www.shellcheck.net).",
+  "check_python": "Failed flake8 Python lint check.",
+  "check_terraform": "Failed Terraform check. More details below."
+  "check_ansible": "Failed ansible-lint check. More details below."
+  "check_whitespace": "Failed whitespace check. More details below.",
+}'
+rval=0
+failed_tests=()
+tests=(
+  check_shell
+  check_headers
+  check_python
+  check_terraform
+  check_ansible
+  # disabling check_whitespace for now. It produces too many errors at the moment.
+  #check_whitespace
+)
+
+# parse args
+for arg in "$@"
+do
+  case $arg in
+    -m|--markdown)
+      MARKDOWN=1
+      shift
+      ;;
+    -c=*|--contrib-guide=*)
+      CONTRIBUTING_GUIDE="${arg#*=}"
+      shift
+      ;;
+      *) # end argument parsing
+      shift
+      ;;
+  esac
+done
+
+for test in "${tests[@]}"; do
+  # if not in markdown mode, pipe test output to stdout tty
+  # nested if condition is a workaround for test[[]] not echoing some outputs from check_* tests even with subshell
+  if [[ $MARKDOWN -eq 0 ]]; then
+    if ! "${test}"; then
+      failed_tests+=("${test}")
+      ((rval++))
+    fi
+  # if control reaches here - in markdown mode, pipe test stderr to stdout for capture
+  elif ! output=$(${test} 2>&1); then
+    # add test name to list of failed_tests
+    failed_tests+=("${test}")
+    ((rval++))
+    # clean output color, sqash multiple empty blank lines
+    output=$(echo "$output" | sed -r "s/\x1b\[[0-9;]*m/\n/g" | tr -s '\n')
+    # try to get a helpful error message, otherwise unknown
+    error_help_message=$(echo "$messages" | jq  --arg check_name "$test" -r '.[$check_name] // "🦖 An unknown error has occurred" ')
+    #construct markdown body
+    MARKDOWN_STR+="- ⚠️${test}\n ${error_help_message} \n \`\`\`bash \n${output}\n \`\`\` \n"
+  fi
+done
+
+# if any tests have failed
+if [[ "${#failed_tests[@]}" -ne 0 ]]; then
+  # echo output in markdown
+  if [[ $MARKDOWN -eq 1 ]]; then
+  header="Thanks for the PR! 🚀\nUnfortunately it looks like some of our CI checks failed. See the [Contributing Guide](${CONTRIBUTING_GUIDE}) for details.\n"
+  echo -e "${header}${MARKDOWN_STR}"
+  else
+    # shellcheck disable=SC2145  # Output all elements of the array
+    echo "Error: The following tests have failed: ${failed_tests[@]}"
+    exit "${rval}"
+  fi
+fi


### PR DESCRIPTION
This commit introduces linting capabilities for this repo. Linting
is done via a container that defined in build/Dockerfile. Linting
is implemented using the following techonologies:
- ansilbe code linting via ansible-lint
- terraform code linting via terraform fmt and terraform validate
- python code linting via flake8
- shell code linting via shellcheck
In addition to the above we also check if the files have proper
license header requires by Google PSO.
This commit also introduces cloud-build configuration that is
initial step towards CI/CD for this repo.
Linting is NOT performed on the third_party/ and venv/ directories

The code has been inspired by CFT CI/CD code. Please see
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/tree/master/infra/build/developer-tools
for more information